### PR TITLE
Build DagFactory DAGs when there is an invalid YAML in the DAGs folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
           architecture: "x64"
 
       - run: pip3 install hatch
-      - run: hatch run tests.py3.12-2.10:static-check
+      - run: CONFIG_ROOT_DIR=`pwd`"/dags" hatch run tests.py3.12-2.10:static-check

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ logs/
 # VIM
 *.sw[a-z]
 
+# Airflow
+examples/.airflowignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8-slim
 ARG AIRFLOW_VERSION=2.0.0
 ARG AIRFLOW_HOME=/usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
+ENV CONFIG_ROOT_DIR=/usr/local/airflow/dags/
 
 RUN set -ex \
     && buildDeps=' \

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -178,9 +178,7 @@ def load_yaml_dags(
         suffix = [".yaml", ".yml"]
     candidate_dag_files = []
     for suf in suffix:
-        candidate_dag_files = list(
-            chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}"))
-        )
+        candidate_dag_files = list(chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")))
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
         logging.info("Loading %s", config_file_abs_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -60,10 +60,13 @@ class DagFactory:
 
             yaml.add_constructor("!join", __join, yaml.FullLoader)
 
-            config: Dict[str, Any] = yaml.load(
-                stream=open(config_filepath, "r", encoding="utf-8"),
-                Loader=yaml.FullLoader,
-            )
+            with open(config_filepath, "r", encoding="utf-8") as fp:
+                yaml.add_constructor("!join", __join, yaml.FullLoader)
+                config_with_env = os.path.expandvars(fp.read())
+                config: Dict[str, Any] = yaml.load(
+                    stream=config_with_env,
+                    Loader=yaml.FullLoader,
+                )
         except Exception as err:
             raise DagFactoryConfigException("Invalid DAG Factory config file") from err
         return config

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -178,9 +178,15 @@ def load_yaml_dags(
         suffix = [".yaml", ".yml"]
     candidate_dag_files = []
     for suf in suffix:
-        candidate_dag_files = chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}"))
-
+        candidate_dag_files = list(chain(
+            candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")
+        ))
+    logging.info(candidate_dag_files)
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
-        DagFactory(config_file_abs_path).generate_dags(globals_dict)
-        logging.info("DAG loaded: %s", config_file_path)
+        logging.info(f"Loading {config_file_abs_path}")
+        try:
+            DagFactory(config_file_abs_path).generate_dags(globals_dict)
+            logging.info("DAG loaded: %s", config_file_path)
+        except Exception as e:
+            logging.warning(f"Failed to load dag from {config_file_path}: {e}")

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -178,14 +178,14 @@ def load_yaml_dags(
         suffix = [".yaml", ".yml"]
     candidate_dag_files = []
     for suf in suffix:
-        candidate_dag_files = list(chain(
-            candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")
-        ))
+        candidate_dag_files = list(
+            chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}"))
+        )
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
-        logging.info(f"Loading {config_file_abs_path}")
+        logging.info("Loading %s", config_file_abs_path)
         try:
             DagFactory(config_file_abs_path).generate_dags(globals_dict)
             logging.info("DAG loaded: %s", config_file_path)
         except Exception as e:
-            logging.warning(f"Failed to load dag from {config_file_path}: {e}")
+            logging.exception("Failed to load dag from %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -187,5 +187,5 @@ def load_yaml_dags(
         try:
             DagFactory(config_file_abs_path).generate_dags(globals_dict)
             logging.info("DAG loaded: %s", config_file_path)
-        except Exception as e:
+        except Exception:  # pylint: disable=broad-except
             logging.exception("Failed to load dag from %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -181,7 +181,6 @@ def load_yaml_dags(
         candidate_dag_files = list(chain(
             candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")
         ))
-    logging.info(candidate_dag_files)
     for config_file_path in candidate_dag_files:
         config_file_abs_path = str(config_file_path.absolute())
         logging.info(f"Loading {config_file_abs_path}")

--- a/examples/datasets/example_dag_datasets.py
+++ b/examples/datasets/example_dag_datasets.py
@@ -1,8 +1,17 @@
-from airflow import DAG
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+
 import dagfactory
 
 
-config_file = "/usr/local/airflow/dags/datasets/example_dag_datasets.yml"
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "datasets/example_dag_datasets.yml")
+
 example_dag_factory = dagfactory.DagFactory(config_file)
 
 # Creating task dependencies

--- a/examples/datasets/example_dag_datasets.yml
+++ b/examples/datasets/example_dag_datasets.yml
@@ -40,13 +40,13 @@ example_custom_config_dataset_producer_dag:
       operator: airflow.operators.bash_operator.BashOperator
       bash_command: "echo 1"
       outlets:
-        file: /usr/local/airflow/dags/datasets/example_config_datasets.yml
+        file: $CONFIG_ROOT_DIR/datasets/example_config_datasets.yml
         datasets: ['dataset_custom_1', 'dataset_custom_2']
 
 example_custom_config_dataset_consumer_dag:
   description: "Example DAG consumer custom config datasets"
   schedule:
-    file: /usr/local/airflow/dags/datasets/example_config_datasets.yml
+    file: $CONFIG_ROOT_DIR/datasets/example_config_datasets.yml
     datasets: ['dataset_custom_1', 'dataset_custom_2']
   tasks:
     task_1:

--- a/examples/example_customize_operator.py
+++ b/examples/example_customize_operator.py
@@ -1,8 +1,17 @@
-from airflow import DAG
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+
 import dagfactory
 
 
-config_file = "/usr/local/airflow/dags/example_customize_operator.yml"
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_customize_operator.yml")
+
 example_dag_factory = dagfactory.DagFactory(config_file)
 
 # Creating task dependencies

--- a/examples/example_dag_factory.py
+++ b/examples/example_dag_factory.py
@@ -1,7 +1,17 @@
-from airflow import DAG
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+
 import dagfactory
 
-config_file = "/usr/local/airflow/dags/example_dag_factory.yml"
+
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_dag_factory.yml")
+
 example_dag_factory = dagfactory.DagFactory(config_file)
 
 # Creating task dependencies

--- a/examples/example_dag_factory.yml
+++ b/examples/example_dag_factory.yml
@@ -12,9 +12,9 @@ default:
   orientation: "LR"
   schedule_interval: "0 1 * * *"
   on_success_callback_name: print_hello
-  on_success_callback_file: /usr/local/airflow/dags/print_hello.py
+  on_success_callback_file: $CONFIG_ROOT_DIR/print_hello.py
   on_failure_callback_name: print_hello
-  on_failure_callback_file: /usr/local/airflow/dags/print_hello.py
+  on_failure_callback_file: $CONFIG_ROOT_DIR/print_hello.py
 
 example_dag:
   default_args:
@@ -34,7 +34,7 @@ example_dag:
     task_3:
       operator: airflow.operators.python_operator.PythonOperator
       python_callable_name: print_hello
-      python_callable_file: /usr/local/airflow/dags/print_hello.py
+      python_callable_file: $CONFIG_ROOT_DIR/print_hello.py
       dependencies: [task_1]
 
 example_dag2:
@@ -84,7 +84,7 @@ example_dag4:
     task_3:
       operator: airflow.operators.python_operator.PythonOperator
       python_callable_name: print_hello
-      python_callable_file: /Users/buraky/Projects/dag-factory/examples/print_hello.py
+      python_callable_file: $CONFIG_ROOT_DIR/print_hello.py
       task_group_name: task_group_1
       dependencies: [task_2]
     task_4:

--- a/examples/example_dynamic_task_mapping.py
+++ b/examples/example_dynamic_task_mapping.py
@@ -1,8 +1,16 @@
-from airflow import DAG
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+
 import dagfactory
 
 
-config_file = "/usr/local/airflow/dags/example_dynamic_task_mapping.yml"
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_dynamic_task_mapping.yml")
 example_dag_factory = dagfactory.DagFactory(config_file)
 
 # Creating task dependencies

--- a/examples/example_dynamic_task_mapping.yml
+++ b/examples/example_dynamic_task_mapping.yml
@@ -9,11 +9,11 @@ test_expand:
     request:
       operator: airflow.operators.python.PythonOperator
       python_callable_name: example_task_mapping
-      python_callable_file: /usr/local/airflow/dags/expand_tasks.py
+      python_callable_file: $CONFIG_ROOT_DIR/expand_tasks.py
     process:
       operator: airflow.operators.python_operator.PythonOperator
       python_callable_name: expand_task
-      python_callable_file: /usr/local/airflow/dags/expand_tasks.py
+      python_callable_file: $CONFIG_ROOT_DIR/expand_tasks.py
       partial:
         op_kwargs:
           test_id: "test"

--- a/examples/invalid.yaml
+++ b/examples/invalid.yaml
@@ -1,0 +1,9 @@
+name: John Doe
+age: 30
+is_student: yes
+address:
+  street: 123 Main St
+  city: New York
+  postal_code 10001
+- phone: 555-1234
+email: johndoe@example.com

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+import logging
 
 import pytest
 from airflow.models.variable import Variable
@@ -431,13 +432,14 @@ def test_set_callback_after_loading_config():
     td.generate_dags(globals())
 
 
-def test_load_yaml_dags_fail():
-    with pytest.raises(Exception):
-        load_yaml_dags(
-            globals_dict=globals(),
-            dags_folder="tests/fixtures",
-            suffix=["invalid_yaml.yml"],
-        )
+def test_load_invalid_yaml_logs_error(caplog):
+    caplog.set_level(logging.ERROR)
+    load_yaml_dags(
+        globals_dict=globals(),
+        dags_folder="tests/fixtures",
+        suffix=["invalid_yaml.yml"],
+    )
+    assert caplog.messages == ['Failed to load dag from tests/fixtures/invalid_yaml.yml']
 
 
 def test_load_yaml_dags_succeed():

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from pathlib import Path
+
+import airflow
+from airflow.models.dagbag import DagBag
+from packaging.version import Version
+
+
+EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "examples"
+AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
+AIRFLOW_VERSION = Version(airflow.__version__)
+
+
+MIN_VER_DAG_FILE_VER: dict[str, list[str]] = {
+    "2.3": ["example_dynamic_task_mapping.py"],
+}
+
+
+def test_no_import_errors():
+    with open(AIRFLOW_IGNORE_FILE, "w+") as file:
+        for min_version, files in MIN_VER_DAG_FILE_VER.items():
+            if AIRFLOW_VERSION < Version(min_version):
+                print(f"Adding {files} to .airflowignore")
+                file.writelines([f"{file}\n" for file in files])
+
+    db = DagBag(EXAMPLE_DAGS_DIR, include_examples=False)
+    assert db.dags
+    assert not db.import_errors

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps =
     markupsafe>=1.1.1,<2.1.0
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:////tmp/airflow.db
+    CONFIG_ROOT_DIR = {toxinidir}/examples
+    PYTHONPATH = {toxinidir}:{toxinidir}/examples:{env:PYTHONPATH}
 commands =
     airflow db init
     pytest --cov=dagfactory tests -p no:warnings --verbose --color=yes --cov-report=xml
@@ -34,6 +36,8 @@ deps =
     markupsafe>=1.1.1,<2.1.0
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:////tmp/airflow.db
+    CONFIG_ROOT_DIR = {toxinidir}/examples
+    PYTHONPATH = {toxinidir}:{toxinidir}/examples:{env:PYTHONPATH}
 commands =
     airflow db init
     pytest --cov=dagfactory tests -p no:warnings --verbose --color=yes --cov-report=xml
@@ -48,6 +52,8 @@ deps =
     markupsafe>=1.1.1,<2.1.0
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:////tmp/airflow.db
+    CONFIG_ROOT_DIR = {toxinidir}/examples
+    PYTHONPATH = {toxinidir}:{toxinidir}/examples:{env:PYTHONPATH}
 commands =
     airflow db init
     pytest --cov=dagfactory tests -p no:warnings --verbose --color=yes --cov-report=xml


### PR DESCRIPTION
Before, when the Airflow DAGs folder had an invalid YAML file, no DagFactory DAGs would be loaded. This PR changes this behaviour to log any invalid YAML file paths but render valid DagFactory YAML-based DAGs.

Co-authored-by: Tatiana Al-Chueyr <tatiana.alchueyr@gmail.com>