### PR TITLE
Added callback_file & callback_name to default_args DAG level and tests

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -240,21 +240,27 @@ class DagBuilder:
         if utils.check_dict_key(
             dag_params["default_args"], "on_success_callback_name"
         ) and utils.check_dict_key(
-            dag_params["default_args"], "on_success_callback_file"):
+            dag_params["default_args"], "on_success_callback_file"
+        ):
 
-            dag_params["default_args"]["on_success_callback"]: Callable = utils.get_python_callable(
-                dag_params["default_args"]["on_success_callback_name"],
-                dag_params["default_args"]["on_success_callback_file"],
+            dag_params["default_args"]["on_success_callback"]: Callable = (
+                utils.get_python_callable(
+                    dag_params["default_args"]["on_success_callback_name"],
+                    dag_params["default_args"]["on_success_callback_file"],
+                )
             )
 
         if utils.check_dict_key(
             dag_params["default_args"], "on_failure_callback_name"
         ) and utils.check_dict_key(
-            dag_params["default_args"], "on_failure_callback_file"):
+            dag_params["default_args"], "on_failure_callback_file"
+        ):
 
-            dag_params["default_args"]["on_failure_callback"]: Callable = utils.get_python_callable(
-                dag_params["default_args"]["on_failure_callback_name"],
-                dag_params["default_args"]["on_failure_callback_file"],
+            dag_params["default_args"]["on_failure_callback"]: Callable = (
+                utils.get_python_callable(
+                    dag_params["default_args"]["on_failure_callback_name"],
+                    dag_params["default_args"]["on_failure_callback_file"],
+                )
             )
 
         if utils.check_dict_key(dag_params, "template_searchpath"):

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -237,6 +237,26 @@ class DagBuilder:
                 dag_params["on_failure_callback_file"],
             )
 
+        if utils.check_dict_key(
+            dag_params["default_args"], "on_success_callback_name"
+        ) and utils.check_dict_key(
+            dag_params["default_args"], "on_success_callback_file"):
+
+            dag_params["default_args"]["on_success_callback"]: Callable = utils.get_python_callable(
+                dag_params["default_args"]["on_success_callback_name"],
+                dag_params["default_args"]["on_success_callback_file"],
+            )
+
+        if utils.check_dict_key(
+            dag_params["default_args"], "on_failure_callback_name"
+        ) and utils.check_dict_key(
+            dag_params["default_args"], "on_failure_callback_file"):
+
+            dag_params["default_args"]["on_failure_callback"]: Callable = utils.get_python_callable(
+                dag_params["default_args"]["on_failure_callback_name"],
+                dag_params["default_args"]["on_failure_callback_file"],
+            )
+
         if utils.check_dict_key(dag_params, "template_searchpath"):
             if isinstance(dag_params["template_searchpath"], (list, str)) and utils.check_template_searchpath(
                 dag_params["template_searchpath"]


### PR DESCRIPTION
Hi astro team!

This PR brings the following enhancements:

1) Unittest for DAG-Level Callback using parameters:

**_on_success_callback_name_** & **_on_success_callback_file_**
**_on_failure_callback_name_** & **_on_failure_callback_file_**

[Astro instruction on how to apply these parameters](https://www.astronomer.io/docs/learn/dag-factory#step-4-optional-add-a-dag-level-callback)

2) While I find the existing callback feature useful which allows specifying callback code at any location, this PR takes it a step further by enabling callbacks to be specified within the DAG's _default_args_. With this enhancement, the callbacks will automatically propagate to the task level as well. This update aligns with how [default_args](https://airflow.apache.org/docs/apache-airflow/2.9.2/core-concepts/dags.html#default-arguments) are passed in Airflow. Additionally, I’ve included unit tests. 

