### PR TITLE
[WEBSITE] Add scarf to readme for website analytics

### DIFF
--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -1,0 +1,3 @@
+# Privacy Notice
+
+This project follows the [Privacy Policy of Astronomer](https://www.astronomer.io/privacy/)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPi](https://img.shields.io/pypi/v/dag-factory.svg)](https://pypi.org/project/dag-factory/)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Downloads](https://pepy.tech/badge/dag-factory)](https://pepy.tech/project/dag-factory)
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=2bb92a5b-beb3-48cc-a722-79dda1089eda" />
 
 Welcome to *dag-factory*! *dag-factory* is a library for [Apache Airflow®](https://airflow.apache.org) to construct DAGs declaratively via configuration files. 
 


### PR DESCRIPTION
This adds website analytics to the Dag-Factory readme. Scarf privacy policy: https://about.scarf.sh/privacy-policy

Note that while you cannot explicitly opt-out of website analytics for the publicly hosted readme (and docs), Scarf respects browser DND. If that is set via the browser, telemetry for that user will not be sent to Scarf.