### PR TITLE
Fix running tests locally (outside of the CI)

### DIFF
--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+from pathlib import Path
 from unittest.mock import patch
 
 import pendulum
@@ -47,7 +48,9 @@ else:
     MappedOperator = None
 # pylint: disable=ungrouped-imports,invalid-name
 
-here = os.path.dirname(__file__)
+here = Path(__file__).parent
+
+PROJECT_ROOT_PATH = str(here.parent)
 
 DEFAULT_CONFIG = {
     "default_args": {
@@ -654,8 +657,8 @@ def test_get_dag_params_with_template_searchpath():
         td.get_dag_params()
 
     assert utils.check_template_searchpath(123) == False
-    assert utils.check_template_searchpath("/home/runner/work") == True
-    assert utils.check_template_searchpath(["/home/runner/work"]) == True
+    assert utils.check_template_searchpath(PROJECT_ROOT_PATH) == True
+    assert utils.check_template_searchpath([PROJECT_ROOT_PATH]) == True
 
 
 def test_get_dag_params_with_render_template_as_native_obj():


### PR DESCRIPTION
Before this change, they raised the following error when running `AIRFLOW_HOME=`pwd` make test `:

```
========================================================== FAILURES ==========================================================
________________________________________ test_get_dag_params_with_template_searchpath ________________________________________

    def test_get_dag_params_with_template_searchpath():
        from dagfactory import utils

        td = dagbuilder.DagBuilder(
            "test_dag", {"template_searchpath": ["./sql"]}, DEFAULT_CONFIG
        )
        error_message = "template_searchpath must be absolute paths"
        with pytest.raises(Exception, match=error_message):
            td.get_dag_params()

        td = dagbuilder.DagBuilder(
            "test_dag", {"template_searchpath": ["/sql"]}, DEFAULT_CONFIG
        )
        error_message = "template_searchpath must be existing paths"
        with pytest.raises(Exception, match=error_message):
            td.get_dag_params()

        td = dagbuilder.DagBuilder(
            "test_dag", {"template_searchpath": "./sql"}, DEFAULT_CONFIG
        )
        error_message = "template_searchpath must be absolute paths"
        with pytest.raises(Exception, match=error_message):
            td.get_dag_params()

        td = dagbuilder.DagBuilder(
            "test_dag", {"template_searchpath": "/sql"}, DEFAULT_CONFIG
        )
        error_message = "template_searchpath must be existing paths"
        with pytest.raises(Exception, match=error_message):
            td.get_dag_params()

        assert utils.check_template_searchpath(123) == False
>       assert utils.check_template_searchpath("/home/runner/work") == True

tests/test_dagbuilder.py:657:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

template_searchpath = '/home/runner/work'

    def check_template_searchpath(template_searchpath: Union[str, List[str]]) -> bool:
        """
        Check if template_searchpath is valid
        :param template_searchpath: a list or str to test
        :type template_searchpath: Union[str, List[str]]
        :return: result to check
        :type: bool
        """
        if isinstance(template_searchpath, str):
            if not os.path.isabs(template_searchpath):
                raise DagFactoryException("template_searchpath must be absolute paths")
            if not os.path.isdir(template_searchpath):
>               raise DagFactoryException("template_searchpath must be existing paths")
E               dagfactory.exceptions.DagFactoryException: template_searchpath must be existing paths

dagfactory/utils.py:204: DagFactoryException

--------- coverage: platform darwin, python 3.10.14-final-0 ----------
Coverage XML written to file coverage.xml

================================================== short test summary info ===================================================
FAILED tests/test_dagbuilder.py::test_get_dag_params_with_template_searchpath - dagfactory.exceptions.DagFactoryException: template_searchpath must be existing paths
================================================ 1 failed, 79 passed in 1.17s ================================================
py310-airflow2: exit 1 (1.57 seconds) /Users/tati/Code/dag-factory> pytest --cov=dagfactory tests -p no:warnings --verbose --color=yes --cov-report=xml pid=55426
.pkg: _exit> python /Users/tati/Code/dag-factory/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
  py38-airflow1108: OK (2.16 seconds)
  py38-airflow2: FAIL code 1 (5.23=setup[2.41]+cmd[1.23,1.59] seconds)
  py39-airflow1108: OK (1.85 seconds)
  py39-airflow2: FAIL code 1 (6.48=setup[2.18]+cmd[2.61,1.70] seconds)
  py310-airflow1108: OK (2.24 seconds)
  py310-airflow2: FAIL code 1 (6.71=setup[2.53]+cmd[2.60,1.57] seconds)
  evaluation failed :( (24.70 seconds)
make: *** [test] Error 255
```