### PR TITLE
Cast callbacks to functions when set with default_args on task groups

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -179,8 +179,16 @@ class DagBuilder:
 
         if utils.check_dict_key(dag_params["default_args"], "sla_miss_callback"):
             if isinstance(dag_params["default_args"]["sla_miss_callback"], str):
-                dag_params["default_args"]["sla_miss_callback"]: Callable = import_string(
+                dag_params["default_args"]["sla_miss_callback"] = import_string(
                     dag_params["default_args"]["sla_miss_callback"]
+                )
+
+        if utils.check_dict_key(dag_params["default_args"], "on_execute_callback") and version.parse(
+            AIRFLOW_VERSION
+        ) >= version.parse("2.0.0"):
+            if isinstance(dag_params["default_args"]["on_execute_callback"], str):
+                dag_params["default_args"]["on_execute_callback"] = import_string(
+                    dag_params["default_args"]["on_execute_callback"]
                 )
 
         if utils.check_dict_key(dag_params["default_args"], "on_success_callback"):
@@ -544,6 +552,47 @@ class DagBuilder:
             for task_group_name, task_group_conf in task_groups.items():
                 task_group_conf["group_id"] = task_group_name
                 task_group_conf["dag"] = dag
+
+                if version.parse(AIRFLOW_VERSION) >= version.parse("2.2.0") and isinstance(
+                    task_group_conf.get("default_args"), dict
+                ):
+                    # https://github.com/apache/airflow/pull/16557
+                    if utils.check_dict_key(task_group_conf["default_args"], "on_success_callback"):
+                        if isinstance(
+                            task_group_conf["default_args"]["on_success_callback"],
+                            str,
+                        ):
+                            task_group_conf["default_args"]["on_success_callback"]: Callable = import_string(
+                                task_group_conf["default_args"]["on_success_callback"]
+                            )
+
+                    if utils.check_dict_key(task_group_conf["default_args"], "on_execute_callback"):
+                        if isinstance(
+                            task_group_conf["default_args"]["on_execute_callback"],
+                            str,
+                        ):
+                            task_group_conf["default_args"]["on_execute_callback"]: Callable = import_string(
+                                task_group_conf["default_args"]["on_execute_callback"]
+                            )
+
+                    if utils.check_dict_key(task_group_conf["default_args"], "on_failure_callback"):
+                        if isinstance(
+                            task_group_conf["default_args"]["on_failure_callback"],
+                            str,
+                        ):
+                            task_group_conf["default_args"]["on_failure_callback"]: Callable = import_string(
+                                task_group_conf["default_args"]["on_failure_callback"]
+                            )
+
+                    if utils.check_dict_key(task_group_conf["default_args"], "on_retry_callback"):
+                        if isinstance(
+                            task_group_conf["default_args"]["on_retry_callback"],
+                            str,
+                        ):
+                            task_group_conf["default_args"]["on_retry_callback"]: Callable = import_string(
+                                task_group_conf["default_args"]["on_retry_callback"]
+                            )
+
                 task_group = TaskGroup(**{k: v for k, v in task_group_conf.items() if k not in SYSTEM_PARAMS})
                 task_groups_dict[task_group.group_id] = task_group
         return task_groups_dict
@@ -572,11 +621,13 @@ class DagBuilder:
                 name = f"{group_id}.{name}"
             if conf.get("dependencies"):
                 source: Union[BaseOperator, "TaskGroup"] = tasks_and_task_groups_instances[name]
+
                 for dep in conf["dependencies"]:
                     if tasks_and_task_groups_config[dep].get("task_group"):
                         group_id = tasks_and_task_groups_config[dep]["task_group"].group_id
                         dep = f"{group_id}.{dep}"
                     dep: Union[BaseOperator, "TaskGroup"] = tasks_and_task_groups_instances[dep]
+
                     source.set_upstream(dep)
 
     @staticmethod

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -130,44 +130,6 @@ DAG_CONFIG_TASK_GROUP = {
         },
     },
 }
-DAG_CONFIG_TASK_GROUP_WITH_CALLBACKS = {
-    "default_args": {"owner": "custom_owner"},
-    "schedule_interval": "0 3 * * *",
-    "task_groups": {
-        "task_group_1": {
-            "tooltip": "this is a task group",
-            "default_args": {
-                "on_failure_callback": f"{__name__}.print_context_callback",
-                "on_success_callback": f"{__name__}.print_context_callback",
-                "on_execute_callback": f"{__name__}.print_context_callback",
-                "on_retry_callback": f"{__name__}.print_context_callback",
-            },
-        },
-    },
-    "tasks": {
-        "task_1": {
-            "operator": "airflow.operators.bash_operator.BashOperator",
-            "bash_command": "echo 1",
-            "task_group_name": "task_group_1",
-        },
-        "task_2": {
-            "operator": "airflow.operators.bash_operator.BashOperator",
-            "bash_command": "echo 2",
-            "task_group_name": "task_group_1",
-        },
-        "task_3": {
-            "operator": "airflow.operators.bash_operator.BashOperator",
-            "bash_command": "echo 3",
-            "task_group_name": "task_group_1",
-            "dependencies": ["task_2"],
-        },
-        "task_4": {
-            "operator": "airflow.operators.bash_operator.BashOperator",
-            "bash_command": "echo 4",
-            "dependencies": ["task_group_1"],
-        },
-    },
-}
 DAG_CONFIG_DYNAMIC_TASK_MAPPING = {
     "default_args": {"owner": "custom_owner"},
     "description": "This is an example dag with dynamic task mapping",
@@ -235,6 +197,45 @@ DAG_CONFIG_CALLBACK = {
     },
 }
 UTC = pendulum.timezone("UTC")
+
+DAG_CONFIG_TASK_GROUP_WITH_CALLBACKS = {
+    "default_args": {"owner": "custom_owner"},
+    "schedule_interval": "0 3 * * *",
+    "task_groups": {
+        "task_group_1": {
+            "tooltip": "this is a task group",
+            "default_args": {
+                "on_failure_callback": f"{__name__}.print_context_callback",
+                "on_success_callback": f"{__name__}.print_context_callback",
+                "on_execute_callback": f"{__name__}.print_context_callback",
+                "on_retry_callback": f"{__name__}.print_context_callback",
+            },
+        },
+    },
+    "tasks": {
+        "task_1": {
+            "operator": "airflow.operators.bash_operator.BashOperator",
+            "bash_command": "echo 1",
+            "task_group_name": "task_group_1",
+        },
+        "task_2": {
+            "operator": "airflow.operators.bash_operator.BashOperator",
+            "bash_command": "echo 2",
+            "task_group_name": "task_group_1",
+        },
+        "task_3": {
+            "operator": "airflow.operators.bash_operator.BashOperator",
+            "bash_command": "echo 3",
+            "task_group_name": "task_group_1",
+            "dependencies": ["task_2"],
+        },
+        "task_4": {
+            "operator": "airflow.operators.bash_operator.BashOperator",
+            "bash_command": "echo 4",
+            "dependencies": ["task_group_1"],
+        },
+    },
+}
 
 
 class MockTaskGroup:


### PR DESCRIPTION
Hello!

When used in the task group's default_args, callbacks are passed as strings to the tasks, which ends up generating failures.

The idea is to perform the same parse used in make_task (it is necessary to check whether the default_args attribute is defined, since it is optional and defaults to None) and perhaps in the future modularize this conversion functionality in order to cover the widespread use of default_args.