### PR TITLE
Fix `make docker-run`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8-slim
 
-ARG AIRFLOW_VERSION=2.0.0
+ARG AIRFLOW_VERSION=2.8.0
+ARG PYTHON_VERSION=3.8
 ARG AIRFLOW_HOME=/usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 ENV CONFIG_ROOT_DIR=/usr/local/airflow/dags/
@@ -19,6 +20,7 @@ RUN set -ex \
     && apt-get update -yqq \
     && apt-get upgrade -yqq \
     && apt-get install -yqq --no-install-recommends \
+    && apt-get install curl -y \
     $buildDeps \
     freetds-bin \
     build-essential \
@@ -34,7 +36,13 @@ RUN set -ex \
     /usr/share/doc \
     /usr/share/doc-base
 
-RUN pip install apache-airflow[http]==${AIRFLOW_VERSION}
+ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-$AIRFLOW_VERSION/constraints-$PYTHON_VERSION.txt"
+RUN curl -sSL $CONSTRAINT_URL -o /tmp/constraint.txt
+# Workaround to remove PyYAML constraint that will work on both Linux and MacOS
+RUN sed '/PyYAML==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
+RUN mv /tmp/constraint.txt.tmp /tmp/constraint.txt
+
+RUN pip install apache-airflow[http]==${AIRFLOW_VERSION}  --constraint /tmp/constraint.txt
 ADD . /
 RUN pip install -e .
 


### PR DESCRIPTION
The `make docker-run` currently appears to be broken. 
The changes in this PR attempt to resolve the errors by installing Airflow
with its constraints. 

related: #206 