### PR TITLE
Configure GitHub to automate publishing DAG Factory in PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@
       - Code-Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Publish package in PyPi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build wheels and source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade build
+
+      - name: Build source distribution
+        run: python -m build
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: dist
+
+      - name: Push build artifacts to PyPi
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,20 @@
-name: Publish package in PyPi
-
-on:
-  release:
-    types: [published]
-
-jobs:
-  build:
-    name: Build wheels and source distribution
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install build dependencies
-        run: python -m pip install --upgrade build
-
-      - name: Build source distribution
-        run: python -m build
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: dist/*
-          if-no-files-found: error
-
-  publish:
-    name: Publish release
+  Publish-Package:
+    if: github.event_name == 'release'
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
     needs:
-      - build
+      - Static-Check
+      - Run-Unit-Tests
+      - Code-Coverage
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
-          name: artifacts
-          path: dist
-
-      - name: Push build artifacts to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          python-version: '3.10'
+          architecture: 'x64'
+      - run: pip3 install hatch
+      - run: hatch build
+      - run: hatch publish
+    env:
+      HATCH_INDEX_USER: __token__
+      HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,17 @@ Source = "https://github.com/astronomer/dag-factory"
 [tool.hatch.version]
 path = "dagfactory/__init__.py"
 
+[tool.hatch.build]
+sources = ["."]
+
 [tool.hatch.build.targets.sdist]
 include = ["dagfactory"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["dagfactory"]
+
+[tool.distutils.bdist_wheel]
+universal = true
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
Automate the release process using GitHub actions so we can consistently make release 0.20.0 and future releases.

As part of this change, I've already generated a PyPI upload token and configured the environment variable `PYPI_TOKEN` as a GitHub secret.