### PR TITLE
Fix Pytest fixture that changed DAG YAML file

### DIFF
--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -33,7 +33,7 @@ example_dag:
       - task_1
       operator: airflow.operators.bash_operator.BashOperator
 example_dag2:
-  doc_md_file_path: {here}/fixtures/mydocfile.md
+  doc_md_file_path: $PWD/tests/fixtures/mydocfile.md
   schedule_interval: None
   tasks:
     task_1:
@@ -53,7 +53,7 @@ example_dag3:
   doc_md_python_arguments:
     arg1: arg1
     arg2: arg2
-  doc_md_python_callable_file: {here}/fixtures/doc_md_builder.py
+  doc_md_python_callable_file: $PWD/tests/fixtures/doc_md_builder.py
   doc_md_python_callable_name: mydocmdbuilder
   tasks:
     task_1:

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -91,18 +91,6 @@ DAG_FACTORY_CALLBACK_CONFIG = {
 }
 
 
-@pytest.fixture(autouse=True)
-def build_path_for_doc_md():
-    with open(TEST_DAG_FACTORY, "r") as f:
-        oldText = f.read()
-        newText = oldText.replace("{here}", here)
-    with open(TEST_DAG_FACTORY, "w") as f:
-        f.write(newText)
-    yield
-    with open(TEST_DAG_FACTORY, "w") as f:
-        f.write(oldText)
-
-
 def test_validate_config_filepath_valid():
     dagfactory.DagFactory._validate_config_filepath(TEST_DAG_FACTORY)
 


### PR DESCRIPTION
A Pytest fixture modified a DAG YAML file, which is not in .gitignore.

The consequence is that if there were errors, the fixture was changed and developers would potentially commit an invalid fixture - that would be invalid in the CI.

This PR leverages the previous change introduced in #236 to use envvars for templating YML filepaths..