### PR TITLE
Fix `README.md` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dag-factory
 
-[![Github Actions](https://github.com/ajbosco/dag-factory/workflows/build/badge.svg?branch=master&event=push)](https://github.com/ajbosco/dag-factory/actions?workflow=build)
-[![Coverage](https://codecov.io/github/ajbosco/dag-factory/coverage.svg?branch=master)](https://codecov.io/github/ajbosco/dag-factory?branch=master)
+[![Github Actions](https://github.com/astronomer/dag-factory/workflows/build/badge.svg?branch=master&event=push)](https://github.com/astronomer/dag-factory/actions?workflow=build)
+[![Coverage](https://codecov.io/github/astronomer/dag-factory/coverage.svg?branch=master)](https://codecov.io/github/astronomer/dag-factory?branch=master)
 [![PyPi](https://img.shields.io/pypi/v/dag-factory.svg)](https://pypi.org/project/dag-factory/)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Downloads](https://pepy.tech/badge/dag-factory)](https://pepy.tech/project/dag-factory)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Coverage](https://codecov.io/github/astronomer/dag-factory/coverage.svg?branch=master)](https://codecov.io/github/astronomer/dag-factory?branch=master)
 [![PyPi](https://img.shields.io/pypi/v/dag-factory.svg)](https://pypi.org/project/dag-factory/)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Downloads](https://pepy.tech/badge/dag-factory)](https://pepy.tech/project/dag-factory)
+[![Downloads](https://img.shields.io/pypi/dm/dag-factory.svg)](hhttps://img.shields.io/pypi/dm/dag-factory)
+
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=2bb92a5b-beb3-48cc-a722-79dda1089eda" />
 
 Welcome to *dag-factory*! *dag-factory* is a library for [Apache Airflow®](https://airflow.apache.org) to construct DAGs declaratively via configuration files.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://codecov.io/github/astronomer/dag-factory/coverage.svg?branch=master)](https://codecov.io/github/astronomer/dag-factory?branch=master)
 [![PyPi](https://img.shields.io/pypi/v/dag-factory.svg)](https://pypi.org/project/dag-factory/)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Downloads](https://img.shields.io/pypi/dm/dag-factory.svg)](hhttps://img.shields.io/pypi/dm/dag-factory)
+[![Downloads](https://img.shields.io/pypi/dm/dag-factory.svg)](https://img.shields.io/pypi/dm/dag-factory)
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=2bb92a5b-beb3-48cc-a722-79dda1089eda" />
 


### PR DESCRIPTION
Before this change, the README badges still pointed to the previous project owner and were not being updated. For example, code coverage is currently close to 90%, but it still displayed 81%.

Now badges refer to the new official repo, displaying up-to-date stats.

Additionally, previously we were using a website that incorrectly displayed a badge stating DAG Factory had 10M downloads - I fixed to use the official PyPI badge, with real PyPI stats (e.g. 415k downloads in the last month). 

<img width="1479" alt="Screenshot 2024-10-17 at 11 27 40" src="https://github.com/user-attachments/assets/475a77de-39cf-40b5-ae4c-25f0cc8806d6">
