### PR TITLE
Fix Makefile to run make docker-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ clean: ## Removes build and test artifacts
 
 
 .PHONY: build-whl
-build-whl: ## Build installable whl file
-	cd examples && ln -s ../dev/dags dags
+build-whl: setup-dev ## Build installable whl file
+	cd dev
 	python3 -m build --outdir dev/include/
 
 .PHONY: docker-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ tests = [
 
 [tool.hatch.envs.tests]
 dependencies = [
+    "build",
     "dag-factory[tests]",
     "apache-airflow~={matrix:airflow}.0,!=2.9.0,!=2.9.1",  # https://github.com/apache/airflow/pull/39670
     "httpx>=0.25.0"


### PR DESCRIPTION
Fixes the following errors that popped up when trying to run `make docker-run`:

```
(venv) ➜  dag-factory git:(release-0.2.0) ✗ make build-whl
cd examples && ln -s ../dev/dags dags
ln: dags/dags: File exists
make: *** [build-whl] Error 1
```

And
```
(venv) ➜  dag-factory git:(release-0.2.0) ✗ make docker-run 
cd dev
python3 -m build --outdir dev/include/
/Users/tati/Code/dag-factory/venv/bin/python3: No module named build
make: *** [build-whl] Error 1
```