### PR TITLE
Remove off looking start-date value in example_dag yaml config

### DIFF
--- a/dev/dags/example_dag_factory.yml
+++ b/dev/dags/example_dag_factory.yml
@@ -19,7 +19,6 @@ default:
 example_dag:
   default_args:
     owner: "custom_owner"
-    start_date: 2 days
   description: "this is an example dag"
   schedule_interval: "0 3 * * *"
   render_template_as_native_obj: True


### PR DESCRIPTION
The `example_dag` in the `example_dag_factory.yml` has a `start_date` 
value set to `2 days`, which seems unclear and problematic. It’s not clear 
what this value represents, and it appears to be causing issues with the 
DAG, preventing it from running tasks. I confirmed this issue also exists in 
version `0.19.0`, so it’s not related to any changes made after that version. 
When I removed this questionable `start_date` value, the DAG ran its tasks 
successfully.

closes: #274