### PR TITLE
Remove pytest durations from tests

### DIFF
--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -16,5 +16,4 @@ pytest -vv \
     --cov=dagfactory \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m integration

--- a/scripts/test/unit-cov.sh
+++ b/scripts/test/unit-cov.sh
@@ -3,5 +3,4 @@ pytest \
     --cov=dagfactory \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     --ignore=tests/test_example_dags.py

--- a/scripts/test/unit.sh
+++ b/scripts/test/unit.sh
@@ -1,4 +1,3 @@
 pytest \
     -vv \
-    --durations=0 \
     --ignore=tests/test_example_dags.py


### PR DESCRIPTION
Even though the --durations flag can be very helpful in debugging and troubleshooting test durations, to have it in a permanent basis adds overhead to the tests and obfuscates us seeing more relevant data, such as coverage report.