### PR TITLE
Remove DAG retries check since many DAGs have different retry values

### DIFF
--- a/dev/tests/dags/test_dag_example.py
+++ b/dev/tests/dags/test_dag_example.py
@@ -64,11 +64,3 @@ def test_dag_tags(dag_id, dag, fileloc):
     assert dag.tags, f"{dag_id} in {fileloc} has no tags"
     if APPROVED_TAGS:
         assert not set(dag.tags) - APPROVED_TAGS
-
-
-@pytest.mark.parametrize("dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()])
-def test_dag_retries(dag_id, dag, fileloc):
-    """
-    test if a DAG has retries set
-    """
-    assert dag.default_args.get("retries", None) >= 2, f"{dag_id} in {fileloc} must have task retries >= 2."


### PR DESCRIPTION
This test fails with the existing DAGs and does not bring value to DAG Factory test suite.