### PR TITLE
Improve integration tests scripts

### DIFF
--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -9,8 +9,8 @@ if [ -L "dags" ]; then
 elif [ -e "dags" ]; then
     echo "'dags' exists but is not a symbolic link. Please resolve this manually."
 else
-    echo "Symbolic link 'dags' created successfully."
     ln -s dev/dags dags
+    echo "Symbolic link 'dags' created successfully."
 fi
 
 rm -rf airflow.*

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -4,6 +4,15 @@ set -v
 set -x
 set -e
 
+if [ -L "dags" ]; then
+    echo "Symbolic link 'dags' already exists."
+elif [ -e "dags" ]; then
+    echo "'dags' exists but is not a symbolic link. Please resolve this manually."
+else
+    echo "Symbolic link 'dags' created successfully."
+    ln -s dev/dags dags
+fi
+
 rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -10,8 +10,6 @@ ls $AIRFLOW_HOME
 
 airflow db check
 
-ln -s dev/dags dags
-
 pytest -vv \
     --cov=dagfactory \
     --cov-report=term-missing \


### PR DESCRIPTION
When running locally, they would generate a symbolic link inside the dags symbolic link, if it previously existed.

This PR solves these limitations.