### PR TITLE
Create initial documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# DAG Factory documentation
+
+Everything you need to know about how to build Airflow workflows using YAML files.
+
+## Getting started
+
+Are you new to DAG Factory? This is the place to start!
+
+* [DAG Factory at a glance]()
+* [Install guide]()
+* [Using YAML instead of Python]()
+    * [Traditional Airflow Operators]()
+    * [TaskFlow API]()
+
+
+## Features
+
+* [Configuring your workflows]()
+    * Environment variables
+    * Defaults
+* [Defining actions upon task states]()
+    * Callbacks
+* [Dynamically creating tasks during runtime]()
+    * Dynamic task mapping
+
+
+## Getting help
+
+Having trouble? We'd like to help!
+
+* Report bugs, questions and feature requests in our [ticket tracker](https://github.com/astronomer/dag-factory/issues).
+
+
+## Contributing
+
+DAG Factory is an Open-Source project. Learn about its development process and about how you can contribute:
+
+* [Contributing to DAG Factory]()
+* [Github repository](https://github.com/astronomer/dag-factory/)
+
+## License
+
+To learn more about the terms and conditions for use, reproduction and distribution, read the [Apache License 2.0](../LICENSE).
+
+
+## Privacy Notice
+
+This project follows [Astronomer's Privacy Policy](https://www.astronomer.io/privacy/).
+
+For further information, [read this](../PRIVACY_NOTICE.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # DAG Factory documentation
 
-Everything you need to know about how to build Airflow workflows using YAML files.
+Everything you need to know about how to build Apache Airflow® workflows using YAML files.
 
 ## Getting started
 


### PR DESCRIPTION
Create a first version of a docs index page so we have a unified place to link the documentation we'll create in the follow-up PRs.