### PR TITLE
Propogate provided dag_display_name to built dag

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -637,6 +637,7 @@ class DagBuilder:
         dag_kwargs: Dict[str, Any] = {}
 
         dag_kwargs["dag_id"] = dag_params["dag_id"]
+        dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
 
         if not dag_params.get("timetable") and not utils.check_dict_key(dag_params, "schedule"):
             dag_kwargs["schedule_interval"] = dag_params.get("schedule_interval", timedelta(days=1))

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -637,7 +637,8 @@ class DagBuilder:
         dag_kwargs: Dict[str, Any] = {}
 
         dag_kwargs["dag_id"] = dag_params["dag_id"]
-        dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
+        if version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0"):
+            dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
 
         if not dag_params.get("timetable") and not utils.check_dict_key(dag_params, "schedule"):
             dag_kwargs["schedule_interval"] = dag_params.get("schedule_interval", timedelta(days=1))

--- a/dev/dags/example_dag_factory.yml
+++ b/dev/dags/example_dag_factory.yml
@@ -22,6 +22,7 @@ example_dag:
   description: "this is an example dag"
   schedule_interval: "0 3 * * *"
   render_template_as_native_obj: True
+  dag_display_name: "Pretty Example DAG"
   tasks:
     task_1:
       operator: airflow.operators.bash_operator.BashOperator

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -624,7 +624,8 @@ def test_build():
     assert isinstance(actual["dag"], DAG)
     assert len(actual["dag"].tasks) == 3
     assert actual["dag"].task_dict["task_1"].downstream_task_ids == {"task_2", "task_3"}
-    assert actual["dag"].dag_display_name == "Pretty example dag"
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0"):
+        assert actual["dag"].dag_display_name == "Pretty example dag"
     if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.8"):
         assert actual["dag"].tags == ["tag1", "tag2", "dagfactory"]
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -65,6 +65,7 @@ DAG_CONFIG = {
     "doc_md": "##here is a doc md string",
     "default_args": {"owner": "custom_owner"},
     "description": "this is an example dag",
+    "dag_display_name": "Pretty example dag",
     "schedule_interval": "0 3 * * *",
     "tags": ["tag1", "tag2"],
     "render_template_as_native_obj": True,
@@ -374,6 +375,7 @@ def test_get_dag_params():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
     expected = {
         "doc_md": "##here is a doc md string",
+        "dag_display_name": "Pretty example dag",
         "dag_id": "test_dag",
         "default_args": {
             "owner": "custom_owner",
@@ -622,6 +624,7 @@ def test_build():
     assert isinstance(actual["dag"], DAG)
     assert len(actual["dag"].tasks) == 3
     assert actual["dag"].task_dict["task_1"].downstream_task_ids == {"task_2", "task_3"}
+    assert actual["dag"].dag_display_name == "Pretty example dag"
     if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.8"):
         assert actual["dag"].tags == ["tag1", "tag2", "dagfactory"]
 


### PR DESCRIPTION
This PR propagates the `dag_display_name` value set in the YAML dag config to the built dag object.
The support for associating `dag_display_name` was added in Airflow 2.9.0, hence, we only associate it
for the supported versions.

Preview of the built dag with dag_display_name being set.
<img width="1008" alt="Screenshot 2024-12-31 at 5 40 29 PM" src="https://github.com/user-attachments/assets/8b1f59ff-0b1e-4d24-b640-95dcf87c1919" />


closes: #233 