### PR TITLE
Add incipient documentation tooling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: DAG Factory Documentation
+extra:
+  version:
+    provider: mike
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      check_paths: true
+      base_path: [ "." ]
+  - pymdownx.superfences
+
+plugins:
+  - mike:
+      alias_type: symlink

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,22 @@ minversion = "6.0"
 markers = ["integration", "callbacks"]
 
 ######################################
+# DOCS
+######################################
+
+[tool.hatch.envs.docs]
+dependencies = [
+    "mkdocs",
+    "mike",
+    "pymdown-extensions",
+]
+
+[tool.hatch.envs.docs.scripts]
+build = "mike deploy --push dev"
+serve = "mike serve"
+release = "version=$(python -W ignore -c 'import dagfactory; print(dagfactory.__version__)') && mike deploy --push --update-aliases $version latest"
+
+######################################
 # THIRD PARTY TOOLS
 ######################################
 


### PR DESCRIPTION
This PR introduces an incipient version for documentation tooling in DAG Factory.

It introduces three requirements to create/generate documentation:
- Mkdocs (tool recommended by the Astronomer docs team)
- [Mike](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/) (for documentation versioning)
- [`pymdown-extensions`](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions) (so we can leverage [Snippets](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files) for injecting code from other files inline in the Markdown files)

Also, it introduces three new hatch commands:
- `hatch run docs:build`: builds the docs locally, generating the correspondent static HTML website;
- `hatch run docs:serve`: builds and serves the docs locally at localhost:8080;
- `hatch run docs:release`: creates a version release using the version specified in `dagfactory/__init__.py` using Mike 

This screenshot illustrates versioning:
<img width="1363" alt="Screenshot 2025-01-02 at 10 11 18" src="https://github.com/user-attachments/assets/a37a2076-769f-4cc9-aef1-ec8e285d0ae0" />

This screenshot illustrates code snippets:
<img width="1352" alt="Screenshot 2025-01-02 at 10 11 40" src="https://github.com/user-attachments/assets/edaff981-533e-498a-915c-a8be879a40c5" />
