### PR TITLE
Support loading default_args from shared defaults.yml

### DIFF
--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -45,19 +45,14 @@ class DagFactory:
             with open(default_args_yml, "r") as file:
                 return yaml.safe_load(file)
 
-    def deep_merge(self, dict1, dict2):
-        for key, value in dict2.items():
-            if isinstance(value, dict) and key in dict1 and isinstance(dict1[key], dict):
-                dict1[key] = self.deep_merge(dict1[key], value)
-            else:
-                dict1[key] = value
-        return dict1
-
     def _merge_default_args(self):
         global_default_args = self._global_default_args()
         default_config: Dict[str, Any] = self.get_default_config()
 
-        return self.deep_merge(global_default_args, default_config)
+        merged_config = global_default_args.copy()
+        merged_config.update(default_config)
+
+        return merged_config
 
     @staticmethod
     def _serialise_config_md(dag_name, dag_config, default_config):

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -13,8 +13,6 @@ from airflow.models import DAG
 from dagfactory.dagbuilder import DagBuilder
 from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
 
-# rom dagfactory.utils import merge_configs
-
 # these are params that cannot be a dag name
 SYSTEM_PARAMS: List[str] = ["default", "task_groups"]
 

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -49,6 +49,9 @@ class DagFactory:
         global_default_args = self._global_default_args()
         default_config: Dict[str, Any] = self.get_default_config()
 
+        if global_default_args is None:
+            return default_config
+
         merged_config = global_default_args.copy()
         merged_config.update(default_config)
 

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -128,7 +128,10 @@ class DagFactory:
         default_config: Dict[str, Any] = self.get_default_config()
 
         if global_default_args is not None:
-            default_config = {"default_args": {**global_default_args["default_args"], **default_config["default_args"]}}
+            if "default_args" in default_config and "default_args" in global_default_args:
+                default_config = {
+                    "default_args": {**global_default_args["default_args"], **default_config["default_args"]}
+                }
 
         dags: Dict[str, Any] = {}
 

--- a/dev/dags/defaults.yml
+++ b/dev/dags/defaults.yml
@@ -1,0 +1,3 @@
+default_args:
+  start_date: "2024-01-01"
+  owner: "default_owner1"

--- a/dev/dags/defaults.yml
+++ b/dev/dags/defaults.yml
@@ -1,3 +1,3 @@
 default_args:
-  start_date: "2024-01-01"
+  start_date: "2025-01-01"
   owner: "global_owner"

--- a/dev/dags/defaults.yml
+++ b/dev/dags/defaults.yml
@@ -1,3 +1,3 @@
 default_args:
   start_date: "2024-01-01"
-  owner: "default_owner1"
+  owner: "global_owner"

--- a/tests/fixtures/defaults.yml
+++ b/tests/fixtures/defaults.yml
@@ -1,0 +1,3 @@
+default_args:
+  start_date: "2024-01-01"
+  owner: "global_owner"

--- a/tests/fixtures/defaults.yml
+++ b/tests/fixtures/defaults.yml
@@ -1,3 +1,4 @@
 default_args:
-  start_date: "2024-01-01"
+  start_date: "2025-01-01"
   owner: "global_owner"
+  depends_on_past: true

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -486,26 +486,3 @@ def test_yml_dag_rendering_in_docs():
     with open(dag_path, "r") as file:
         expected_doc_md = "## YML DAG\n```yaml\n" + file.read() + "\n```"
     assert generated_doc_md == expected_doc_md
-
-
-@pytest.mark.parametrize(
-    "mock_global, mock_local, expected_merged",
-    [
-        # Test case 1: global config is empty, but local config exists
-        ({}, {"key1": "value1", "key2": "value2"}, {"key1": "value1", "key2": "value2"}),
-        # Test case 2: global config and local config have non-overlapping keys
-        ({"key1": "value1"}, {"key2": "value2"}, {"key1": "value1", "key2": "value2"}),
-        # Test case 3: global config and local config have overlapping keys (local config overrides global)
-        (
-            {"key1": "global_value1", "key2": "global_value2"},
-            {"key2": "local_value2", "key3": "local_value3"},
-            {"key1": "global_value1", "key2": "local_value2", "key3": "local_value3"},
-        ),
-    ],
-)
-def test_merge_default_args(mock_global, mock_local, expected_merged):
-    dag_factory = dagfactory.DagFactory(config=DAG_FACTORY_CONFIG)
-
-    result = dag_factory._merge_default_args(mock_global, mock_local)
-
-    assert result == expected_merged

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -404,7 +404,6 @@ def test_dagfactory_dict():
         },
         "default_view": "graph",
         "schedule_interval": "@daily",
-        "depends_on_past": True,
     }
     expected_dag = {
         "example_dag": {

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -450,10 +450,11 @@ def test_set_callback_after_loading_config():
     td.generate_dags(globals())
 
 
-def test_build_dag_with_global_deafult(monkeypatch):
-    monkeypatch.setattr("dagfactory.dagfactory.settings.DAGS_FOLDER", DEFAULT_ARGS_CONFIG_ROOT)
+def test_build_dag_with_global_default(monkeypatch):
     monkeypatch.setattr(Path, "exists", lambda self: True)
-    dags = dagfactory.DagFactory(config=DAG_FACTORY_CONFIG).build_dags()
+    dags = dagfactory.DagFactory(
+        config=DAG_FACTORY_CONFIG, default_args_config_path=DEFAULT_ARGS_CONFIG_ROOT
+    ).build_dags()
 
     assert dags.get("example_dag").tasks[0].depends_on_past == True
 

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import os
-from pathlib import Path
 
 import pytest
 from airflow import __version__ as AIRFLOW_VERSION
@@ -450,8 +449,7 @@ def test_set_callback_after_loading_config():
     td.generate_dags(globals())
 
 
-def test_build_dag_with_global_default(monkeypatch):
-    monkeypatch.setattr(Path, "exists", lambda self: True)
+def test_build_dag_with_global_default():
     dags = dagfactory.DagFactory(
         config=DAG_FACTORY_CONFIG, default_args_config_path=DEFAULT_ARGS_CONFIG_ROOT
     ).build_dags()

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -447,6 +447,7 @@ def test_set_callback_after_loading_config():
     td.config["default"]["default_args"]["on_success_callback"] = dagfactory.DagFactory(
         config=DAG_FACTORY_CONFIG
     ).build_dags
+    td.generate_dags(globals())
 
 
 def test_build_dag_with_global_deafult(monkeypatch):

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -490,11 +490,11 @@ def test_yml_dag_rendering_in_docs():
 @pytest.mark.parametrize(
     "mock_global, mock_local, expected_merged",
     [
-        # Test case 2: global config is empty, but local config exists
+        # Test case 1: global config is empty, but local config exists
         ({}, {"key1": "value1", "key2": "value2"}, {"key1": "value1", "key2": "value2"}),
-        # Test case 3: global config and local config have non-overlapping keys
+        # Test case 2: global config and local config have non-overlapping keys
         ({"key1": "value1"}, {"key2": "value2"}, {"key1": "value1", "key2": "value2"}),
-        # Test case 4: global config and local config have overlapping keys (local config overrides global)
+        # Test case 3: global config and local config have overlapping keys (local config overrides global)
         (
             {"key1": "global_value1", "key2": "global_value2"},
             {"key2": "local_value2", "key3": "local_value3"},


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/297

Currently, DAG Factory provides two places to configure default_args:

1. At the top of the YML file.
2. In the DAG configuration YML.

The second option overrides the first one.

Post this PR, the user can also keep the default_args in the `defaults.yml` file. The configuration from  `defaults.yml`  will be applied to all DAG Factory DAG

Sample `defaults.yml`
```
default_args:
  start_date: "2025-01-01"
  owner: "global_owner"
  depends_on_past: true
```

The precedence for default_args will be as follows, after this implementation:

1. At DAG configuration YML
2. At the top of the YML file
3. default.yml

i.e At DAG configuration YML will take precedence.


