### PR TITLE
Use absolute URLs for failing links in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,11 @@ DAG Factory is an Open-Source project. Learn about its development process and a
 
 ## License
 
-To learn more about the terms and conditions for use, reproduction and distribution, read the [Apache License 2.0](../LICENSE).
+To learn more about the terms and conditions for use, reproduction and distribution, read the [Apache License 2.0](https://github.com/astronomer/dag-factory/blob/main/LICENSE).
 
 
 ## Privacy Notice
 
 This project follows [Astronomer's Privacy Policy](https://www.astronomer.io/privacy/).
 
-For further information, [read this](../PRIVACY_NOTICE.md)
+For further information, [read this](https://github.com/astronomer/dag-factory/blob/main/PRIVACY_NOTICE.md)


### PR DESCRIPTION
When running `hatch run docs:build` locally, warnings are reported indicating that the linked pages for LICENSE and PRIVACY_NOTICE cannot be found. This occurs because those GitHub pages are outside the context of the built and shipped documentation, leading to errors when clicking those links. To address this, I am updating the links to use absolute GitHub URLs to correctly locate these files.

The warning message is as below:
```
INFO    -  Building documentation to directory: /Users/pankajkoti/astronomer/dag-factory/site
INFO    -  Doc file 'index.md' contains an unrecognized relative link '../LICENSE', it was left as is.
WARNING -  Doc file 'index.md' contains a link '../PRIVACY_NOTICE.md', but the target is not found among documentation files.
```

And clicking on those links in the served docs, gives an error as shown in below screenshot:
<img width="454" alt="Screenshot 2025-01-03 at 12 00 29 PM" src="https://github.com/user-attachments/assets/9f2457f0-92fd-4bce-904c-379382d3cbec" />
