### PR TITLE
Reduce telemetry timeout from 5 to 1 second

### DIFF
--- a/dagfactory/constants.py
+++ b/dagfactory/constants.py
@@ -1,3 +1,3 @@
 TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/dag-factory/{telemetry_version}/{dagfactory_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}"
 TELEMETRY_VERSION = "v2"
-TELEMETRY_TIMEOUT = 5.0
+TELEMETRY_TIMEOUT = 1.0

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -61,7 +61,7 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
         f"""https://astronomer.gateway.scarf.sh/dag-factory/v2/0.2.0a1/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3""",
-        timeout=5.0,
+        timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
@@ -86,7 +86,7 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
         f"""https://astronomer.gateway.scarf.sh/dag-factory/v2/0.2.0a1/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3""",
-        timeout=5.0,
+        timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success


### PR DESCRIPTION
We had an unreasonably high timeout - reducing to a more acceptable one