### PR TITLE
Add docs about project contributors and their roles

### DIFF
--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -5,7 +5,7 @@ Learn more about the project [contributors roles](roles.md).
 
 ## Committers
 
-* Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti>))
+* Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti))
 * Pankaj Singh ([@pankajastro](https://github.com/pankajastro))
 * Tatiana Al-Chueyr ([@tatiana](https://github.com/tatiana>))
 

--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -7,7 +7,7 @@ Learn more about the project [contributors roles](roles.md).
 
 * Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti))
 * Pankaj Singh ([@pankajastro](https://github.com/pankajastro))
-* Tatiana Al-Chueyr ([@tatiana](https://github.com/tatiana>))
+* Tatiana Al-Chueyr ([@tatiana](https://github.com/tatiana))
 
 ## Emeritus Committers
 

--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -1,0 +1,19 @@
+# Contributors
+
+There are different ways people can contribute to DAG Factory.
+Learn more about the project [contributors roles](roles.md).
+
+## Committers
+
+* Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti>))
+* Pankaj Singh ([@pankajastro](https://github.com/pankajastro))
+* Tatiana Al-Chueyr ([@tatiana](https://github.com/tatiana>))
+
+## Emeritus Committers
+
+* Adam Boscarino ([@ajbosco](https://github.com/ajbosco))
+
+## Contributors
+
+Many people are improving DAG Factory each day.
+Find more contributors [in our GitHub page](https://github.com/astronomer/dag-factory/graphs/contributors).

--- a/docs/contributing/roles.md
+++ b/docs/contributing/roles.md
@@ -1,0 +1,47 @@
+# Contributor roles
+
+Contributors are welcome and are greatly appreciated! Every little bit helps, and we give credit to them.
+
+This document aims to explain the current roles in the DAG Factory project.
+For more information, check [contributing](howto.md).
+
+## Contributors
+
+A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the DAG Factory project.
+
+DAG Factory contributors are listed in the Github [insights page](https://github.com/astronomer/dag-factory/graphs/contributors).
+
+Contributors are responsible for:
+
+* Fixing bugs
+* Refactoring code
+* Improving processes and tooling
+* Adding features
+* Improving the documentation
+
+## Committers
+
+Committers are community members with write access to the [DAG Factory GitHub repository](https://github.com/astronomer/dag-factory).
+They can modify the code and the documentation and accept others' contributions to the repo.
+
+Check [contributors](contributors.md) for the official list of DAG Factory committers.
+
+Committers have the same responsibilities as standard contributors and also perform the following actions:
+
+* Reviewing & merging pull-requests
+* Scanning and responding to GitHub issues, helping triaging them
+
+If you know you are not going to be able to contribute for a long time (for instance, due to a change of job or circumstances), you should inform other maintainers, and we will mark you as "emeritus".
+Emeritus committers will no longer have write access to the repo.
+As merit earned never expires, once an emeritus committer becomes active again, they can simply email another maintainer from Astronomer and ask to be reinstated.
+
+### Pre-requisites to becoming a committer
+
+General prerequisites that we look for in all candidates:
+
+1. Consistent contribution over last few months
+2. Visibility on discussions on the Slack channel or GitHub issues/discussions
+3. Contributions to community health and project's sustainability for the long-term
+4. Understands the project's [contributors guidelines](howto.md).
+Astronomer is responsible and accountable for releasing new versions of DAG Factory in [PyPI](https://pypi.org/project/dag-factory/), following the [milestones](https://github.com/astronomer/dag-factory/milestones).
+Astronomer has the right to grant and revoke write access permissions to the project's official repository for any reason it sees fit.

--- a/docs/contributing/roles.md
+++ b/docs/contributing/roles.md
@@ -42,6 +42,6 @@ General prerequisites that we look for in all candidates:
 1. Consistent contribution over last few months
 2. Visibility on discussions on the Slack channel or GitHub issues/discussions
 3. Contributions to community health and project's sustainability for the long-term
-4. Understands the project's [contributors guidelines](howto.md).
+4. Understands the project's contributors' guidelines.
 Astronomer is responsible and accountable for releasing new versions of DAG Factory in [PyPI](https://pypi.org/project/dag-factory/), following the [milestones](https://github.com/astronomer/dag-factory/milestones).
 Astronomer has the right to grant and revoke write access permissions to the project's official repository for any reason it sees fit.

--- a/docs/contributing/roles.md
+++ b/docs/contributing/roles.md
@@ -3,7 +3,7 @@
 Contributors are welcome and are greatly appreciated! Every little bit helps, and we give credit to them.
 
 This document aims to explain the current roles in the DAG Factory project.
-For more information, check [contributing](howto.md).
+For more information, check the contributing docs.
 
 ## Contributors
 


### PR DESCRIPTION
About roles and project contributors, so we set the grounds for promoting developers to committers and how committers become emeritus contributors.

These documents are heavily based on what we wrote for https://github.com/astronomer/astronomer-cosmos