### PR TITLE
Fix warning message 404 in code_of_conduct docs

### DIFF
--- a/docs/contributing/code_of_conduct.md
+++ b/docs/contributing/code_of_conduct.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[humans@astronomer.io](humans@astronomer.io).
+[humans@astronomer.io](mailto:humans@astronomer.io).
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
Fix warning message
```
WARNING -  Doc file 'contributing/code_of_conduct.md' contains a link 'humans@astronomer.io', but the target 'contributing/humans@astronomer.io' is not found among documentation files. Did you mean
           'mailto:humans@astronomer.io'?
INFO    -  Documentation built in 0.17 seconds

```