### PR TITLE
Install `jq` in container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,4 +2,10 @@ FROM quay.io/astronomer/astro-runtime:12.2.0
 
 ENV CONFIG_ROOT_DIR=/usr/local/airflow/dags/
 
+USER root
+
+RUN apt-get update && apt-get install -y jq
+
+USER astro
+
 RUN pip install /usr/local/airflow/include/*.whl


### PR DESCRIPTION
example_hackernews_plain_airflow and example_hackernews_dagfactory require `jq`