### PR TITLE
Removed Unreleased heading section from the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.22.0] - 2025-01-10
 
 ### Added


### PR DESCRIPTION
Not sure why that existed since we don't keep on updating it, IMO, makes sense to remove that section.