### PR TITLE
feat: bumped http provider versions to 2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.0",
-    "apache-airflow-providers-http",
+    "apache-airflow-providers-http>=2.0.0",
     "apache-airflow-providers-cncf-kubernetes",
     "pyyaml",
     "packaging",


### PR DESCRIPTION
This pull request updates the dependencies in the `pyproject.toml` file to ensure compatibility with newer versions of the packages.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R33): Updated the `apache-airflow-providers-http` dependency to require version `2.0.0` or higher.

Close: https://github.com/astronomer/dag-factory/issues/387