### PR TITLE
Add missing Python file for dynamic task example

### DIFF
--- a/dev/dags/example_dynamic_task_mapping.py
+++ b/dev/dags/example_dynamic_task_mapping.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+import dagfactory
+
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_dynamic_task_mapping.yml")
+
+example_dag_factory = dagfactory.DagFactory(config_file)
+
+# Creating task dependencies
+example_dag_factory.clean_dags(globals())
+example_dag_factory.generate_dags(globals())


### PR DESCRIPTION
The Python DAG file is missing for the configuration file example_dynamic_task_mapping.yml.

This PR add it so that DAG will get trigger in CI