### PR TITLE
Pin `apache-airflow-providers-cncf-kubernetes<10.4.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "apache-airflow>=2.3",
     "apache-airflow-providers-http>=2.0.0",
-    "apache-airflow-providers-cncf-kubernetes",
+    "apache-airflow-providers-cncf-kubernetes<10.4.2", # https://github.com/astronomer/dag-factory/issues/397
     "pyyaml",
     "packaging",
 ]


### PR DESCRIPTION
Pin `apache-airflow-providers-cncf-kubernetes` until we conclude on https://github.com/astronomer/dag-factory/issues/397

<img width="1293" alt="Screenshot 2025-04-15 at 2 02 57 PM" src="https://github.com/user-attachments/assets/c2858c07-0597-47c8-a447-b886fd6e9527" />
