### PR TITLE
Update Airflow supported version 2.3+ in docs

### DIFF
--- a/docs/getting-started/quick-start-airflow-standalone.md
+++ b/docs/getting-started/quick-start-airflow-standalone.md
@@ -7,7 +7,7 @@
 The minimum requirements for **dag-factory** are:
 
 - Python 3.8.0+
-- [Apache Airflow®](https://airflow.apache.org) 2.0+
+- [Apache Airflow®](https://airflow.apache.org) 2.3+
 
 ## Step 1: Create a Python Virtual Environment
 


### PR DESCRIPTION
The Airflow version was updated in [#388](https://github.com/astronomer/dag-factory/pull/388), but the documentation was not updated accordingly. This PR addresses that