### PR TITLE
Catch more specific exceptions

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -153,7 +153,7 @@ class DagBuilder:
         """
         try:
             dag_params: Dict[str, Any] = utils.merge_configs(self.dag_config, self.default_config)
-        except Exception as err:
+        except (TypeError, AttributeError) as err:
             raise DagFactoryConfigException("Failed to merge config with default config") from err
         dag_params["dag_id"]: str = self.dag_name
 
@@ -272,11 +272,11 @@ class DagBuilder:
         try:
             # class is a Callable https://stackoverflow.com/a/34578836/3679900
             timetable_obj: Callable[..., Timetable] = import_string(timetable)
-        except Exception as err:
+        except ImportError as err:
             raise DagFactoryException(f"Failed to import timetable {timetable} due to: {err}") from err
         try:
             schedule: Timetable = timetable_obj(**timetable_params)
-        except Exception as err:  # pragma: no cover
+        except TypeError as err:  # pragma: no cover
             raise DagFactoryException(f"Failed to create {timetable_obj} due to: {err}") from err
         return schedule
 
@@ -355,7 +355,7 @@ class DagBuilder:
         try:
             # class is a Callable https://stackoverflow.com/a/34578836/3679900
             operator_obj: Callable[..., BaseOperator] = import_string(operator)
-        except Exception as err:
+        except ImportError as err:
             raise DagFactoryException(f"Failed to import operator: {operator}") from err
         # pylint: disable=too-many-nested-blocks
         try:
@@ -471,7 +471,7 @@ class DagBuilder:
                 if not expand_kwargs
                 else operator_obj.partial(**task_params).expand(**expand_kwargs)
             )
-        except Exception as err:
+        except (TypeError, DagFactoryException, ValueError) as err:
             raise DagFactoryException(f"Failed to create {operator_obj} task: {err}") from err
         return task
 

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, AnyStr, Dict, List, Match, Optional, Pattern, Tuple, Union
 
 import pendulum
+from pendulum.tz.exceptions import InvalidTimezone
 import yaml
 
 from dagfactory.exceptions import DagFactoryException
@@ -32,7 +33,7 @@ def get_datetime(date_value: Union[str, datetime, date], timezone: str = "UTC") 
     """
     try:
         local_tz: pendulum.timezone = pendulum.timezone(timezone)
-    except Exception as err:
+    except (InvalidTimezone, ValueError) as err:
         raise DagFactoryException("Failed to create timezone") from err
     if isinstance(date_value, datetime):
         return date_value.replace(tzinfo=local_tz)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import os
 
 import pendulum
 import pytest
+from dagfactory.exceptions import DagFactoryException
 
 from dagfactory import utils
 
@@ -243,7 +244,7 @@ def test_is_partial_duplicated():
     task_params = {"key_3": "value3", "key_4": "value4"}
     try:
         utils.is_partial_duplicated(partial_kwargs, task_params)
-    except Exception as e:
+    except DagFactoryException as e:
         assert str(e) == "Duplicated partial kwarg! It's already in task_params."
 
 


### PR DESCRIPTION
## Summary
- narrow broad exception handling to specific ones across dagbuilder, dagfactory and utils
- update tests to expect `DagFactoryException`

fixes https://github.com/astronomer/dag-factory/issues/410

------
https://chatgpt.com/codex/tasks/task_b_6849b9e1cd80832b836cafb9cb59079e