### PR TITLE
Add support for custom type yaml

### DIFF
--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -2,7 +2,7 @@
 
 from .dagfactory import DagFactory, load_yaml_dags
 
-__version__ = "0.23.0a4"
+__version__ = "0.23.0a6"
 __all__ = [
     "DagFactory",
     "load_yaml_dags",

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -12,6 +12,7 @@ from airflow.models import DAG
 
 from dagfactory.dagbuilder import DagBuilder
 from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
+from dagfactory.loader import DAGFactoryLoader
 
 # these are params that cannot be a dag name
 SYSTEM_PARAMS: List[str] = ["default", "task_groups"]
@@ -89,25 +90,25 @@ class DagFactory:
         # pylint: disable=consider-using-with
         try:
 
-            def __join(loader: yaml.FullLoader, node: yaml.Node) -> str:
+            def __join(loader: DAGFactoryLoader, node: yaml.Node) -> str:
                 seq = loader.construct_sequence(node)
                 return "".join([str(i) for i in seq])
 
-            def __or(loader: yaml.FullLoader, node: yaml.Node) -> str:
+            def __or(loader: DAGFactoryLoader, node: yaml.Node) -> str:
                 seq = loader.construct_sequence(node)
                 return " | ".join([f"({str(i)})" for i in seq])
 
-            def __and(loader: yaml.FullLoader, node: yaml.Node) -> str:
+            def __and(loader: DAGFactoryLoader, node: yaml.Node) -> str:
                 seq = loader.construct_sequence(node)
                 return " & ".join([f"({str(i)})" for i in seq])
 
-            yaml.add_constructor("!join", __join, yaml.FullLoader)
-            yaml.add_constructor("!or", __or, yaml.FullLoader)
-            yaml.add_constructor("!and", __and, yaml.FullLoader)
+            yaml.add_constructor("!join", __join, DAGFactoryLoader)
+            yaml.add_constructor("!or", __or, DAGFactoryLoader)
+            yaml.add_constructor("!and", __and, DAGFactoryLoader)
 
             with open(config_filepath, "r", encoding="utf-8") as fp:
                 config_with_env = os.path.expandvars(fp.read())
-                config: Dict[str, Any] = yaml.load(stream=config_with_env, Loader=yaml.FullLoader)
+                config: Dict[str, Any] = yaml.load(stream=config_with_env, Loader=DAGFactoryLoader)
         except Exception as err:
             raise DagFactoryConfigException("Invalid DAG Factory config file") from err
         return config

--- a/dagfactory/loader.py
+++ b/dagfactory/loader.py
@@ -104,11 +104,11 @@ class DAGFactoryLoader(yaml.FullLoader):
     pass
 
 
-# DAGFactoryLoader.add_constructor(
-#     "!!kubernetes.client.models.V1ResourceRequirements", KubernetesConstructor.resource_requirements_constructor
-# )
-# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
-# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
-# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)
+DAGFactoryLoader.add_constructor(
+    "!!kubernetes.client.models.V1ResourceRequirements", KubernetesConstructor.resource_requirements_constructor
+)
+DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
+DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
+DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)
 # Handle unknown tag dynamically
 DAGFactoryLoader.add_constructor(None, _dynamic_object_constructor)

--- a/dagfactory/loader.py
+++ b/dagfactory/loader.py
@@ -64,8 +64,9 @@ class KubernetesConstructor:
 
 
 def _dynamic_object_constructor(loader, node):
-    tag = node.tag.lstrip("!")
-    parts = tag.split(".")
+    tag = node.tag.strip("")
+    class_path = node.tag.split(":")[2]
+    parts = class_path.split(".")
     module_name = ".".join(parts[:-1])
     class_name = parts[-1]
 
@@ -103,11 +104,11 @@ class DAGFactoryLoader(yaml.FullLoader):
     pass
 
 
-DAGFactoryLoader.add_constructor(
-    "!kubernetes.client.models.V1ResourceRequirements", KubernetesConstructor.resource_requirements_constructor
-)
-DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
-DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
-DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)
+# DAGFactoryLoader.add_constructor(
+#     "!!kubernetes.client.models.V1ResourceRequirements", KubernetesConstructor.resource_requirements_constructor
+# )
+# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
+# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
+# DAGFactoryLoader.add_constructor("!!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)
 # Handle unknown tag dynamically
 DAGFactoryLoader.add_constructor(None, _dynamic_object_constructor)

--- a/dagfactory/loader.py
+++ b/dagfactory/loader.py
@@ -1,0 +1,73 @@
+import yaml
+from kubernetes.client import models as k8s
+
+
+class KubernetesConstructor:
+
+    @staticmethod
+    def resource_requirements_constructor(loader, node):
+        data = loader.construct_mapping(node, deep=True)
+        return k8s.V1ResourceRequirements(**data)
+
+    @staticmethod
+    def container_constructor(loader, node):
+        data = loader.construct_mapping(node, deep=True)
+        if "resources" in data and data["resources"] is not None:
+            if isinstance(data["resources"], dict):
+                resource_node = yaml.nodes.MappingNode(
+                    tag="!kubernetes.client.models.V1ResourceRequirements", value=list(data["resources"].items())
+                )
+                data["resources"] = KubernetesConstructor.resource_requirements_constructor(loader, resource_node)
+        if "securityContext" in data and data["securityContext"] is not None:
+            data["security_context"] = k8s.V1PodSecurityContext(**data.pop("securityContext"))
+
+        return k8s.V1Container(**data)
+
+    @staticmethod
+    def pod_spec_constructor(loader, node):
+        data = loader.construct_mapping(node, deep=True)
+
+        if "containers" in data and data["containers"] is not None:
+            converted_containers = []
+            for container_data in data["containers"]:
+                if isinstance(container_data, dict):
+                    container_node = yaml.nodes.MappingNode(
+                        tag="!kubernetes.client.models.V1Container", value=list(container_data.items())
+                    )
+                    converted_containers.append(KubernetesConstructor.container_constructor(loader, container_node))
+                else:
+                    converted_containers.append(container_data)
+            data["containers"] = converted_containers
+        if (
+            "securityContext" in data
+            and data["securityContext"] is not None
+            and isinstance(data["securityContext"], dict)
+        ):
+            data["security_context"] = k8s.V1PodSecurityContext(**data.pop("securityContext"))
+
+        return k8s.V1PodSpec(**data)
+
+    @staticmethod
+    def pod_constructor(loader, node):
+        data = loader.construct_mapping(node, deep=True)
+
+        if "spec" in data and data["spec"] is not None:
+            if isinstance(data["spec"], dict):
+                spec_node = yaml.nodes.MappingNode(
+                    tag="!kubernetes.client.models.V1PodSpec", value=list(data["spec"].items())
+                )
+                data["spec"] = KubernetesConstructor.pod_spec_constructor(loader, spec_node)
+
+        return k8s.V1Pod(**data)
+
+
+class DAGFactoryLoader(yaml.FullLoader):
+    pass
+
+
+DAGFactoryLoader.add_constructor(
+    "!kubernetes.client.models.V1ResourceRequirements", KubernetesConstructor.resource_requirements_constructor
+)
+DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
+DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
+DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)

--- a/dagfactory/loader.py
+++ b/dagfactory/loader.py
@@ -1,3 +1,5 @@
+import importlib
+
 import yaml
 from kubernetes.client import models as k8s
 
@@ -61,6 +63,42 @@ class KubernetesConstructor:
         return k8s.V1Pod(**data)
 
 
+def _dynamic_object_constructor(loader, node):
+    tag = node.tag.lstrip("!")
+    parts = tag.split(".")
+    module_name = ".".join(parts[:-1])
+    class_name = parts[-1]
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        raise yaml.constructor.ConstructorError(f"Could not import module '{module_name}' for tag '{tag}': {e}")
+    try:
+        cls = getattr(module, class_name)
+    except AttributeError:
+        raise yaml.constructor.ConstructorError(
+            f"Class '{class_name}' not found in module '{module_name}' for tag '{tag}'"
+        )
+
+    if isinstance(node, yaml.MappingNode):
+        data = loader.construct_mapping(node, deep=True)
+    elif isinstance(node, yaml.SequenceNode):
+        data = loader.construct_sequence(node, deep=True)
+    elif isinstance(node, yaml.ScalarNode):
+        data = loader.construct_scalar(node)
+    else:
+        raise yaml.constructor.ConstructorError(f"Unsupported YAML node type for dynamic constructor: {type(node)}")
+
+    if isinstance(data, dict):
+        return cls(**data)
+    elif isinstance(data, list) and issubclass(cls, list):
+        return cls(data)
+    elif isinstance(data, str) and issubclass(cls, str):
+        return cls(data)
+    else:
+        return cls(data)
+
+
 class DAGFactoryLoader(yaml.FullLoader):
     pass
 
@@ -71,3 +109,5 @@ DAGFactoryLoader.add_constructor(
 DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Container", KubernetesConstructor.container_constructor)
 DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1PodSpec", KubernetesConstructor.pod_spec_constructor)
 DAGFactoryLoader.add_constructor("!kubernetes.client.models.V1Pod", KubernetesConstructor.pod_constructor)
+# Handle unknown tag dynamically
+DAGFactoryLoader.add_constructor(None, _dynamic_object_constructor)

--- a/dev/dags/example_custom_yaml_type.py
+++ b/dev/dags/example_custom_yaml_type.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+import dagfactory
+
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_custom_yaml_type.yml")
+
+example_dag_factory = dagfactory.DagFactory(config_file)
+
+# Creating task dependencies
+example_dag_factory.clean_dags(globals())
+example_dag_factory.generate_dags(globals())

--- a/dev/dags/example_custom_yaml_type.yml
+++ b/dev/dags/example_custom_yaml_type.yml
@@ -1,0 +1,36 @@
+default:
+  default_args:
+    catchup: false
+    start_date: 2025-06-20
+
+# ----8<---   [ start: example_custom_yaml_type ]
+example_custom_yaml_type:
+  description: "this is an example dag"
+  schedule_interval: "@daily"
+  render_template_as_native_obj: True
+  tasks:
+    task_1:
+      operator: airflow.operators.bash_operator.BashOperator
+      bash_command: "echo 1"
+      executor_config:
+        pod_override: !kubernetes.client.models.V1Pod
+          spec: !kubernetes.client.models.V1PodSpec
+            containers:
+                - !kubernetes.client.models.V1Container
+                  name: "base"
+                  resources: !kubernetes.client.models.V1ResourceRequirements
+                    limits:
+                        "cpu": "1"
+                        "memory": "1024Mi"
+                    requests:
+                        "cpu": "0.5"
+                        "memory": "512Mi"
+    task_2:
+      operator: airflow.operators.bash_operator.BashOperator
+      bash_command: "echo 2"
+      dependencies: [task_1]
+    task_3:
+      operator: airflow.operators.bash_operator.BashOperator
+      bash_command: "echo 2"
+      dependencies: [task_1]
+# ----8<---   [ end: example_custom_yaml_type ]

--- a/dev/dags/example_custom_yaml_type.yml
+++ b/dev/dags/example_custom_yaml_type.yml
@@ -13,18 +13,18 @@ example_custom_yaml_type:
       operator: airflow.operators.bash_operator.BashOperator
       bash_command: "echo 1"
       executor_config:
-        pod_override: !kubernetes.client.models.V1Pod
-          spec: !kubernetes.client.models.V1PodSpec
+        pod_override: !!kubernetes.client.models.V1Pod
+          spec: !!kubernetes.client.models.V1PodSpec
             containers:
-                - !kubernetes.client.models.V1Container
+                - !!kubernetes.client.models.V1Container
                   name: "base"
-                  resources: !kubernetes.client.models.V1ResourceRequirements
+                  resources: !!kubernetes.client.models.V1ResourceRequirements
                     limits:
-                        "cpu": "1"
-                        "memory": "1024Mi"
+                      "cpu": "1"
+                      "memory": "1024Mi"
                     requests:
-                        "cpu": "0.5"
-                        "memory": "512Mi"
+                      "cpu": "0.5"
+                      "memory": "512Mi"
     task_2:
       operator: airflow.operators.bash_operator.BashOperator
       bash_command: "echo 2"


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/426
closes: https://github.com/astronomer/dag-factory/issues/376
closes: https://github.com/astronomer/dag-factory/issues/417
closes: https://github.com/astronomer/dag-factory/issues/104

Support custom type object in yaml DAG. 

TODO: 
- Add tests
- Add docs
- Add support for more object

Example DAG

```
example_custom_yaml_type:
  description: "this is an example dag"
  schedule_interval: "@daily"
  render_template_as_native_obj: True
  tasks:
    task_1:
      operator: airflow.operators.bash_operator.BashOperator
      bash_command: "echo 1"
      executor_config:
        pod_override: !!kubernetes.client.models.V1Pod
          spec: !!kubernetes.client.models.V1PodSpec
            containers:
                - !!kubernetes.client.models.V1Container
                  name: "base"
                  resources: !!kubernetes.client.models.V1ResourceRequirements
                    limits:
                        "cpu": "1"
                        "memory": "1024Mi"
                    requests:
                        "cpu": "0.5"
                        "memory": "512Mi"
    task_2:
      operator: airflow.operators.bash_operator.BashOperator
      bash_command: "echo 2"
      dependencies: [task_1]
    task_3:
      operator: airflow.operators.bash_operator.BashOperator
      bash_command: "echo 2"
      dependencies: [task_1]
```

<img width="1686" alt="Screenshot 2025-06-24 at 12 35 58 PM" src="https://github.com/user-attachments/assets/b2d1b5ed-e7a7-42eb-b752-1c7aaf57ce06" />
