### PR TITLE
Remove expandvars in utils.get_python_callable

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -114,8 +114,6 @@ def get_python_callable(python_callable_name, python_callable_file):
     :type: callable
     """
 
-    python_callable_file = os.path.expandvars(python_callable_file)
-
     if not os.path.isabs(python_callable_file):
         raise DagFactoryException("`python_callable_file` must be absolute path")
 


### PR DESCRIPTION
`expandvars` was initially added to `get_python_callable` to avoid the hard coded path for Py files https://github.com/astronomer/dag-factory/pull/116. Then env var support is added to the entire YAML content https://github.com/astronomer/dag-factory/pull/236. This makes `expandvars` no longer needed in the `get_python_callable` function, hence this PR removes it for better performance.