### PR TITLE
Add DAG example showcasing runtime params usage

### DIFF
--- a/dev/dags/example_params.py
+++ b/dev/dags/example_params.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+
+# The following import is here so Airflow parses this file
+# from airflow import DAG
+import dagfactory
+
+DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
+CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+
+config_file = str(CONFIG_ROOT_DIR / "example_params.yml")
+example_dag_factory = dagfactory.DagFactory(config_file)
+
+# Creating task dependencies
+example_dag_factory.clean_dags(globals())
+example_dag_factory.generate_dags(globals())

--- a/dev/dags/example_params.yml
+++ b/dev/dags/example_params.yml
@@ -1,6 +1,6 @@
 default:
+  catchup: false
   default_args:
-    catchup: false
     start_date: 2025-01-01
 
 example_params:

--- a/dev/dags/example_params.yml
+++ b/dev/dags/example_params.yml
@@ -1,0 +1,20 @@
+default:
+  default_args:
+    catchup: false
+    start_date: 2025-01-01
+
+example_params:
+  params:
+    model_version: 1.0.0
+    input_uri: localhost
+  description: "This is an DAG-Factory example dag with param"
+  schedule_interval: "@daily"
+  tasks:
+    task_1:
+      operator: airflow.operators.bash.BashOperator
+      bash_command: "echo 'Running task 1 with model version {{ params.model_version }} and url: {{ params.input_uri }}'"
+    task_2:
+      operator: airflow.operators.python.PythonOperator
+      params:
+        my_param: 10
+      python_callable: sample.read_params

--- a/dev/dags/sample.py
+++ b/dev/dags/sample.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from random import randint
+from typing import Any
 
 try:
     from airflow.providers.standard.operators.python import get_current_context
@@ -53,5 +54,7 @@ def one_day_ago(execution_date: datetime):
     return execution_date - timedelta(days=1)
 
 
-def read_params(params):
+def read_params(params: dict[str, Any]) -> None:
     print("params: ", params)
+    print("model_version:", params["model_version"])
+    print("my_param:", params["my_param"])

--- a/dev/dags/sample.py
+++ b/dev/dags/sample.py
@@ -51,3 +51,7 @@ def extract_last_name(full_name: str):
 
 def one_day_ago(execution_date: datetime):
     return execution_date - timedelta(days=1)
+
+
+def read_params(params):
+    print("params: ", params)

--- a/docs/configuration/params.md
+++ b/docs/configuration/params.md
@@ -1,0 +1,20 @@
+# Params
+
+**Params** in Airflow are a way to pass dynamic runtime configuration to tasks within a DAG. They allow tasks to be more flexible by enabling templated values to be injected during execution.
+
+## Key Features
+
+- Available in DAG and task definitions.
+- Can be templated using Jinja.
+- Useful for customizing task behavior without modifying code.
+
+## Example DAG
+
+```yaml
+--8<-- "dev/dags/example_params.yml"
+```
+
+## When to Use
+
+- You want to reuse the same DAG for different input values.
+- You want to change a task’s behavior at runtime.

--- a/docs/configuration/params.md
+++ b/docs/configuration/params.md
@@ -1,6 +1,6 @@
 # Params
 
-**Params** in Airflow are a way to pass dynamic runtime configuration to tasks within a DAG. They allow tasks to be more flexible by enabling templated values to be injected during execution.
+[**Params**](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/params.html) in Airflow are a way to pass dynamic runtime configuration to tasks within a DAG. They allow tasks to be more flexible by enabling templated values to be injected during execution.
 
 ## Key Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - configuration/configuring_workflows.md
       - configuration/environment_variables.md
       - configuration/defaults.md
+      - configuration/params.md
       - configuration/schedule.md
   - Features:
       - features/dynamic_tasks.md


### PR DESCRIPTION
Add DAG example showcasing runtime params usage

Relevant discussion:
- https://apache-airflow.slack.com/archives/C03T0AVNA6A/p1750268447189009
- https://astronomer.slack.com/archives/C07CNMS6TKL/p1745588483040239

<img width="1693" alt="Screenshot 2025-06-30 at 12 25 58 PM" src="https://github.com/user-attachments/assets/6bd41e59-2ec5-4f51-b454-6c5c7343fa8a" />

<img width="1715" alt="Screenshot 2025-06-30 at 12 26 25 PM" src="https://github.com/user-attachments/assets/28f48d17-06d5-44f5-9357-84cf5b54b389" />

