### PR TITLE
Add env `AUTO_CONVERT_TO_AF3` in Dockerfile

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,14 +1,16 @@
-FROM quay.io/astronomer/astro-runtime:12.7.0
+# FROM quay.io/astronomer/astro-runtime:12.7.0
+FROM astrocrpublic.azurecr.io/runtime:3.0-4
 
 ENV CONFIG_ROOT_DIR=/usr/local/airflow/dags/
+ENV AUTO_CONVERT_TO_AF3=True
 
 USER root
 
 RUN apt-get update && apt-get install -y jq
 
-USER astro
-
 # Install uv for faster package management
 RUN pip install uv
 
 RUN uv pip install --system /usr/local/airflow/include/*.whl
+
+USER astro


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/442

The issue disappeared after enabling the AUTO_CONVERT_TO_AF3 environment variable, suggesting that the DAG might not have been compatible with Airflow 3

- Add env `AUTO_CONVERT_TO_AF3` in Docker 
- Fix make target `docker-run`
