### PR TITLE
Refactor schedule to use the Python object

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -811,7 +811,10 @@ class DagBuilder:
             if DagBuilder._is_asset(schedule):
                 dag_kwargs["schedule"] = DagBuilder._asset_schedule(schedule)
             else:
-                dag_kwargs["schedule"] = schedule
+                if isinstance(dag_kwargs["schedule"], str) and dag_kwargs["schedule"].lower() == "none":
+                    dag_kwargs["schedule"] = None
+                else:
+                    dag_kwargs["schedule"] = schedule
 
     # pylint: disable=too-many-locals
     def build(self) -> Dict[str, Union[str, DAG]]:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -811,7 +811,7 @@ class DagBuilder:
             if DagBuilder._is_asset(schedule):
                 dag_kwargs["schedule"] = DagBuilder._asset_schedule(schedule)
             else:
-                if isinstance(dag_params["schedule"], str) and dag_kwargs["schedule"].lower() == "none":
+                if isinstance(dag_params["schedule"], str) and dag_params["schedule"].lower() == "none":
                     dag_kwargs["schedule"] = None
                 else:
                     dag_kwargs["schedule"] = schedule

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -811,7 +811,7 @@ class DagBuilder:
             if DagBuilder._is_asset(schedule):
                 dag_kwargs["schedule"] = DagBuilder._asset_schedule(schedule)
             else:
-                if isinstance(dag_kwargs["schedule"], str) and dag_kwargs["schedule"].lower() == "none":
+                if isinstance(dag_params["schedule"], str) and dag_kwargs["schedule"].lower() == "none":
                     dag_kwargs["schedule"] = None
                 else:
                     dag_kwargs["schedule"] = schedule

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -18,7 +18,6 @@ from airflow import DAG, configuration
 from airflow.models import BaseOperator, Variable
 from airflow.utils.module_loading import import_string
 from airflow.version import version as AIRFLOW_VERSION
-from dateutil.relativedelta import relativedelta
 from packaging import version
 
 from dagfactory.constants import AIRFLOW3_MAJOR_VERSION
@@ -718,15 +717,6 @@ class DagBuilder:
         return watchers
 
     @staticmethod
-    def _init_asset(asset_dict: dict):
-        from airflow.sdk import Asset
-
-        """Initialize an Asset from its configuration dictionary."""
-        if "watchers" in asset_dict:
-            asset_dict["watchers"] = DagBuilder._init_watchers(asset_dict["watchers"])
-        return Asset(**asset_dict)
-
-    @staticmethod
     def _combine_assets(assets, op: str):
         """Combine a list of Asset objects using logical operators."""
         if op == "or":
@@ -737,8 +727,27 @@ class DagBuilder:
             raise ValueError(f"Unknown operator: {op}")
 
     @staticmethod
+    def _is_asset(d):
+        from airflow.sdk import Asset
+
+        if not isinstance(d, dict):
+            return False
+        for key, value in d.items():
+            if isinstance(value, Asset):
+                return True
+            elif isinstance(value, list):
+                if any(isinstance(item, Asset) for item in value):
+                    return True
+            elif isinstance(value, dict):
+                if DagBuilder._is_asset(value):
+                    return True
+        return False
+
+    @staticmethod
     def _asset_schedule(value):
         """Recursively parse and construct assets or combinations of assets."""
+        from airflow.sdk import Asset
+
         if isinstance(value, dict):
             if "or" in value:
                 assets = [DagBuilder._asset_schedule(item) for item in value["or"]]
@@ -746,49 +755,12 @@ class DagBuilder:
             elif "and" in value:
                 assets = [DagBuilder._asset_schedule(item) for item in value["and"]]
                 return DagBuilder._combine_assets(assets, "and")
-            elif "uri" in value:
-                return DagBuilder._init_asset(value)
-            else:
-                raise ValueError(f"Invalid asset entry: {value}")
         elif isinstance(value, list):
-            return [DagBuilder._init_asset(asset) for asset in value]
+            return [asset for asset in value]
+        elif isinstance(value, Asset):
+            return value
         else:
             raise TypeError(f"Unexpected data type: {type(value)}")
-
-    @staticmethod
-    def _resolve_schedule(dag_params):
-        schedule = dag_params.get("schedule")
-        if schedule is None:
-            return None
-
-        if isinstance(schedule, str) and schedule.strip().lower() == "none":
-            return None
-
-        # Case 1: If schedule is a string, return it directly
-        if isinstance(schedule, str):
-            return schedule
-
-        # Case 2: If schedule is a dictionary
-        if isinstance(schedule, dict):
-            schedule_type = schedule.get("type")
-            value = schedule.get("value")
-
-            dispatch = {
-                "cron": lambda v: v,
-                "timetable": lambda v: DagBuilder.make_timetable(v.get("callable"), v.get("params", {})),
-                "timedelta": lambda v: timedelta(**v),
-                "relativedelta": lambda v: relativedelta(**v),
-                "assets": lambda v: DagBuilder._asset_schedule(v),
-            }
-
-            try:
-                handler = dispatch[schedule_type]
-            except KeyError:
-                raise DagFactoryException(f"Schedule type {schedule_type} is not supported.")
-
-            return handler(value)
-
-        raise DagFactoryException(f"Unexpected value for schedule: {schedule}")
 
     @staticmethod
     def configure_schedule(dag_params: Dict[str, Any], dag_kwargs: Dict[str, Any]) -> None:
@@ -835,7 +807,11 @@ class DagBuilder:
                 if has_datasets_attr:
                     schedule.pop("datasets")
         else:
-            dag_kwargs["schedule"] = DagBuilder._resolve_schedule(dag_params)
+            schedule = dag_params.get("schedule")
+            if DagBuilder._is_asset(schedule):
+                dag_kwargs["schedule"] = DagBuilder._asset_schedule(schedule)
+            else:
+                dag_kwargs["schedule"] = schedule
 
     # pylint: disable=too-many-locals
     def build(self) -> Dict[str, Union[str, DAG]]:

--- a/docs/configuration/schedule.md
+++ b/docs/configuration/schedule.md
@@ -31,12 +31,6 @@ Below are the supported scheduling types, each with consistent structure and exa
 --8<-- "tests/schedule/cron.yml"
 ```
 
-Or,
-
-```yaml title="Corn Schedule"
---8<-- "tests/schedule/cron_dict.yml"
-```
-
 ### 2. Timedelta Schedule
 
 ```yaml title="Timedelta Schedule"

--- a/tests/schedule/and_asset.yml
+++ b/tests/schedule/and_asset.yml
@@ -1,10 +1,10 @@
 schedule:
-  type: assets
-  value:
-    and:
-      - uri: s3://dag1/output_1.txt
-        extra:
-          hi: bye
-      - uri: s3://dag2/output_1.txt
-        extra:
-          hi: bye
+  and:
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag1/output_1.txt
+      extra:
+        hi: bye
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag2/output_1.txt
+      extra:
+        hi: bye

--- a/tests/schedule/asset_with_watcher.yml
+++ b/tests/schedule/asset_with_watcher.yml
@@ -1,13 +1,11 @@
 schedule:
-  type: asset
-  value:
-    - uri: s3://dag1/output_1.txt
-      extra:
-        hi: bye
-      watchers:
-        - callable: airflow.sdk.AssetWatcher
-          name: test_asset_watcher
-          trigger:
-            callable: airflow.providers.standard.triggers.file.FileDeleteTrigger
-            params:
-              filepath: "/temp/file.txt"
+  __type__: airflow.sdk.Asset
+  uri: s3://dag1/output_1.txt
+  extra:
+    hi: bye
+  watchers:
+    - __type__: airflow.sdk.AssetWatcher
+      name: test_asset_watcher
+      trigger:
+        __type__: airflow.providers.standard.triggers.file.FileDeleteTrigger
+        filepath: "/temp/file.txt"

--- a/tests/schedule/cron_dict.yml
+++ b/tests/schedule/cron_dict.yml
@@ -1,3 +1,0 @@
-schedule:
-  type: cron
-  value: "0 0 * * *"

--- a/tests/schedule/list_asset.yml
+++ b/tests/schedule/list_asset.yml
@@ -1,9 +1,11 @@
 schedule:
-  type: assets
-  value:
-    - uri: s3://dag1/output_1.txt
+  __type__: builtins.list
+  items:
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag1/output_1.txt
       extra:
         hi: bye
-    - uri: s3://dag2/output_1.txt
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag2/output_1.txt
       extra:
         hi: bye

--- a/tests/schedule/nested_asset.yml
+++ b/tests/schedule/nested_asset.yml
@@ -1,14 +1,15 @@
 schedule:
-  type: assets
-  value:
-    or:
-      - and:
-          - uri: s3://dag1/output_1.txt
-            extra:
-              hi: bye
-          - uri: s3://dag2/output_1.txt
-            extra:
-              hi: bye
-      - uri: s3://dag3/output_3.txt
-        extra:
-          hi: bye
+  or:
+    - and:
+        - __type__: airflow.sdk.Asset
+          uri: s3://dag1/output_1.txt
+          extra:
+            hi: bye
+        - __type__: airflow.sdk.Asset
+          uri: s3://dag2/output_1.txt
+          extra:
+            hi: bye
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag3/output_3.txt
+      extra:
+        hi: bye

--- a/tests/schedule/or_asset.yml
+++ b/tests/schedule/or_asset.yml
@@ -1,10 +1,10 @@
 schedule:
-  type: assets
-  value:
-    or:
-      - uri: s3://dag1/output_1.txt
-        extra:
-          hi: bye
-      - uri: s3://dag2/output_1.txt
-        extra:
-          hi: bye
+  or:
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag1/output_1.txt
+      extra:
+        hi: bye
+    - __type__: airflow.sdk.Asset
+      uri: s3://dag2/output_1.txt
+      extra:
+        hi: bye

--- a/tests/schedule/relativedelta.yml
+++ b/tests/schedule/relativedelta.yml
@@ -1,4 +1,3 @@
 schedule:
-  type: relativedelta
-  value:
-      month: 1
+  __type__: dateutil.relativedelta.relativedelta
+  hour: 18

--- a/tests/schedule/timedelta.yml
+++ b/tests/schedule/timedelta.yml
@@ -1,4 +1,3 @@
 schedule:
-  type: timedelta
-  value:
-      seconds: 30
+  __type__: datetime.timedelta
+  seconds: 30

--- a/tests/schedule/timetable.yml
+++ b/tests/schedule/timetable.yml
@@ -1,7 +1,4 @@
 schedule:
-  type: timetable
-  value:
-    callable: airflow.timetables.trigger.CronTriggerTimetable
-    params:
-      cron: "* * * * *"
-      timezone: UTC
+  __type__: airflow.timetables.trigger.CronTriggerTimetable
+  cron: "* * * * *"
+  timezone: UTC

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1151,7 +1151,7 @@ class TestSchedule:
 
         schedule_data = read_yml(schedule_path / "list_asset.yml")
         data = schedule_data["schedule"]
-        parsed_schedule = DagBuilder._asset_schedule(data)
+        parsed_schedule = DagBuilder._asset_schedule(cast_with_type(data))
 
         expected = [
             Asset(


### PR DESCRIPTION
This PR refactor the scheduling to take advantage of the custom Python object introduced in PR: https://github.com/astronomer/dag-factory/pull/444