### PR TITLE
Update cicd.yaml: Use pull_request for authorize as we don't have pull_request_target event configured

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   Authorize:
-    environment: ${{ github.event_name == 'pull_request_target' &&
+    environment: ${{ github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
related: https://github.com/astronomer/oss-integrations-private/issues/156