### PR TITLE
ignore .airflowignore file under dev/dags/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,5 @@ airflow.cfg
 webserver_config.py
 
 # Astro
+dev/dags/.airflowignore
 dev/include/dag_factory-*

--- a/dev/dags/.airflowignore
+++ b/dev/dags/.airflowignore
@@ -1,0 +1,3 @@
+example_map_index_template.py
+example_callbacks.py
+example_http_operator_task.py

--- a/dev/dags/.airflowignore
+++ b/dev/dags/.airflowignore
@@ -1,3 +1,0 @@
-example_map_index_template.py
-example_callbacks.py
-example_http_operator_task.py


### PR DESCRIPTION
`.airflowignore` will be auto created under `dev/dags/` when running airflow standalone during development. It can be ignore to avoid the unnecessary conflicts.