### PR TITLE
Make providers an optional dependency

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -384,7 +384,6 @@ class DagBuilder:
                 )
             else:
                 response_check_name = task_params.pop("response_check_lambda", None)
-
                 task_params["response_check"]: Callable = utils.get_python_callable_lambda(response_check_name)
         return task_params
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -61,6 +61,7 @@ except ImportError:  # pragma: no cover
         HTTP_SENSOR_CLASS = None
         logger.info("Package apache-airflow-providers-http is not installed.")
 
+# Try to import SqlSensor only if the package is installed
 try:
     from airflow.providers.common.sql.sensors.sql import SqlSensor
 
@@ -435,7 +436,7 @@ class DagBuilder:
             # declare both a callable file and a lambda function for success/failure parameter.
             # If both are found the object will not throw and error, instead callable file will
             # take precedence over the lambda function
-            if SQL_SENSOR_CLASS and issubclass(operator_obj, SqlSensor):
+            if SQL_SENSOR_CLASS and issubclass(operator_obj, SQL_SENSOR_CLASS):
                 # Success checks
                 if task_params.get("success_check_file") and task_params.get("success_check_name"):
                     task_params["success"]: Callable = utils.get_python_callable(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -373,14 +373,15 @@ class DagBuilder:
                     `response_check_name` and `response_check_file` parameters \
                     or `response_check_lambda` parameter."
                 )
-            if task_params.get("response_check_file"):
+
+            # remove dag-factory specific parameters
+            # Airflow 2.0 doesn't allow these to
+            response_check_name = task_params.pop("response_check_name", None)
+            response_check_file = task_params.pop("response_check_file", None)
+            if response_check_name:
                 task_params["response_check"]: Callable = utils.get_python_callable(
-                    task_params["response_check_name"], task_params["response_check_file"]
+                    response_check_name, response_check_file
                 )
-                # remove dag-factory specific parameters
-                # Airflow 2.0 doesn't allow these to be passed to operator
-                del task_params["response_check_name"]
-                del task_params["response_check_file"]
             else:
                 task_params["response_check"]: Callable = utils.get_python_callable_lambda(
                     task_params["response_check_lambda"]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -383,12 +383,9 @@ class DagBuilder:
                     response_check_name, response_check_file
                 )
             else:
-                task_params["response_check"]: Callable = utils.get_python_callable_lambda(
-                    task_params["response_check_lambda"]
-                )
-                # remove dag-factory specific parameters
-                # Airflow 2.0 doesn't allow these to be passed to operator
-                del task_params["response_check_lambda"]
+                response_check_name = task_params.pop("response_check_lambda", None)
+
+                task_params["response_check"]: Callable = utils.get_python_callable_lambda(response_check_name)
         return task_params
 
     # pylint: disable=too-many-branches

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -417,7 +417,7 @@ class DagBuilder:
                     )
                     del task_params["failure_check_lambda"]
 
-            if issubclass(operator_obj, HttpSensor):
+            if HTTP_OPERATOR_CLASS and issubclass(operator_obj, HttpSensor):
                 if not (
                     task_params.get("response_check_name") and task_params.get("response_check_file")
                 ) and not task_params.get("response_check_lambda"):

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -58,18 +58,25 @@ except ImportError:  # pragma: no cover
 
 try:
     from airflow.providers.common.sql.sensors.sql import SqlSensor
+
+    SQL_SENSOR_CLASS = SqlSensor
 except ImportError:
     logger.info("Package apache-airflow-providers-common-sql is not installed.")
     SQL_SENSOR_CLASS = None
 
 try:
     from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+
+    KUBERNETES_OPERATOR_CLASS = KubernetesPodOperator
 except ImportError:
     try:
         # TODO: Remove this when apache-airflow-providers-cncf-kubernetes >= 10.0.0
         from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+
+        KUBERNETES_OPERATOR_CLASS = KubernetesPodOperator
     except ImportError:
         logger.info("Package apache-airflow-providers-cncf-kubernetes is not installed.")
+        KUBERNETES_OPERATOR_CLASS = None
 
 try:
     from airflow.providers.cncf.kubernetes import __version__
@@ -85,7 +92,6 @@ except ImportError:  # pragma: no cover
     except ImportError:
         logger.info("Package apache-airflow-providers-cncf-kubernetes is not installed.")
         K8S_PROVIDER_VERSION = "0"
-        KUBERNETES_OPERATOR_CLASS = None
 
 try:
     from airflow.providers.cncf.kubernetes.secret import Secret

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -70,6 +70,7 @@ except ImportError:
     logger.info("Package apache-airflow-providers-common-sql is not installed.")
     SQL_SENSOR_CLASS = None
 
+# Try to import KubernetesPodOperator only if the package is installed
 try:
     from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 
@@ -468,7 +469,8 @@ class DagBuilder:
             ):
                 task_params = DagBuilder._handle_http_sensor(operator_obj, task_params)
 
-            if KUBERNETES_OPERATOR_CLASS and issubclass(operator_obj, KubernetesPodOperator):
+            # Only handle KubernetesPodOperator if the package is installed
+            if KUBERNETES_OPERATOR_CLASS and issubclass(operator_obj, KUBERNETES_OPERATOR_CLASS):
                 task_params = DagBuilder._clean_kpo_task_params(task_params)
 
             DagBuilder.adjust_general_task_params(task_params)

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -52,9 +52,10 @@ except ImportError:  # pragma: no cover
     try:
         # TODO: Remove this when apache-airflow-providers-http >= 5.0.0
         from airflow.providers.http.operators.http import SimpleHttpOperator
+        from airflow.providers.http.sensors.http import HttpSensor
 
         HTTP_OPERATOR_CLASS = SimpleHttpOperator
-        HTTP_SENSOR_CLASS = None
+        HTTP_SENSOR_CLASS = HttpSensor
     except ImportError:  # pragma: no cover
         HTTP_OPERATOR_CLASS = None
         HTTP_SENSOR_CLASS = None
@@ -461,10 +462,8 @@ class DagBuilder:
                     del task_params["failure_check_lambda"]
 
             # Only handle HTTP operator/sensor if the package is installed
-            if (
-                HTTP_OPERATOR_CLASS
-                and HTTP_SENSOR_CLASS
-                and issubclass(operator_obj, (HTTP_OPERATOR_CLASS, HTTP_SENSOR_CLASS))
+            if (HTTP_OPERATOR_CLASS or HTTP_SENSOR_CLASS) and issubclass(
+                operator_obj, (HTTP_OPERATOR_CLASS, HTTP_SENSOR_CLASS)
             ):
                 task_params = DagBuilder._handle_http_sensor(operator_obj, task_params)
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -354,7 +354,7 @@ class DagBuilder:
     @staticmethod
     def _handle_http_sensor(operator_obj, task_params):
         # Only handle if HttpOperator/HttpSensor are available
-        if HTTP_OPERATOR_CLASS and isinstance(operator_obj, HTTP_OPERATOR_CLASS):
+        if HTTP_OPERATOR_CLASS and issubclass(operator_obj, HTTP_OPERATOR_CLASS):
             headers = task_params.get("headers", {})
             content_type = headers.get("Content-Type", "").lower()
 
@@ -388,7 +388,7 @@ class DagBuilder:
                 # remove dag-factory specific parameters
                 # Airflow 2.0 doesn't allow these to be passed to operator
                 del task_params["response_check_lambda"]
-            return task_params
+        return task_params
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements

--- a/dev/dags/example_http_operator_task.py
+++ b/dev/dags/example_http_operator_task.py
@@ -5,8 +5,17 @@ try:
     from airflow.providers.http.operators.http import HttpOperator  # noqa: F401
 
     HTTP_OPERATOR_AVAILABLE = True
+    SIMPLE_HTTP_OPERATOR_AVAILABLE = False
 except ImportError:
-    HTTP_OPERATOR_AVAILABLE = False
+    try:
+        from airflow.providers.http.operators.http import SimpleHttpOperator  # noqa: F401
+
+        SIMPLE_HTTP_OPERATOR_AVAILABLE = True
+        HTTP_OPERATOR_AVAILABLE = False
+    except ImportError:
+        HTTP_OPERATOR_AVAILABLE = False
+        SIMPLE_HTTP_OPERATOR_AVAILABLE = False
+        raise Exception("Package apache-airflow-providers-http is not installed.")
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
@@ -17,8 +26,10 @@ DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 if HTTP_OPERATOR_AVAILABLE:
     config_file = str(CONFIG_ROOT_DIR / "example_http_operator_task.yml")
-else:
+elif SIMPLE_HTTP_OPERATOR_AVAILABLE:
     config_file = str(CONFIG_ROOT_DIR / "example_simple_http_operator_task.yml")
+else:
+    raise Exception("Package apache-airflow-providers-http is not installed.")
 
 example_dag_factory = dagfactory.DagFactory(config_file)
 

--- a/dev/dags/example_http_operator_task.py
+++ b/dev/dags/example_http_operator_task.py
@@ -15,7 +15,7 @@ except ImportError:
     except ImportError:
         HTTP_OPERATOR_AVAILABLE = False
         SIMPLE_HTTP_OPERATOR_AVAILABLE = False
-        raise Exception("Package apache-airflow-providers-http is not installed.")
+        raise ImportError("Package apache-airflow-providers-http is not installed.")
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
@@ -29,7 +29,7 @@ if HTTP_OPERATOR_AVAILABLE:
 elif SIMPLE_HTTP_OPERATOR_AVAILABLE:
     config_file = str(CONFIG_ROOT_DIR / "example_simple_http_operator_task.yml")
 else:
-    raise Exception("Package apache-airflow-providers-http is not installed.")
+    raise ImportError("Package apache-airflow-providers-http is not installed.")
 
 example_dag_factory = dagfactory.DagFactory(config_file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,28 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.4",
-    "apache-airflow-providers-http>=4.0.0",
-    "apache-airflow-providers-cncf-kubernetes>=4.3.0",
     "pyyaml",
     "packaging",
 ]
 
 
 [project.optional-dependencies]
+all = [
+    "apache-airflow>=2.4",
+    "apache-airflow-providers-http>=4.0.0",
+    "apache-airflow-providers-cncf-kubernetes>=4.4.0",
+    "pyyaml",
+    "packaging",
+]
+kubernetes = [
+    "apache-airflow-providers-cncf-kubernetes>=4.4.0",
+]
+http = [
+    "apache-airflow-providers-http>=4.0.0",
+]
+common-sql = [
+    "apache-airflow-providers-common-sql>=1.2.0"
+]
 tests = [
     "apache-airflow-providers-slack",
     "pytest>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ all = [
     "apache-airflow>=2.4",
     "apache-airflow-providers-http>=4.0.0",
     "apache-airflow-providers-cncf-kubernetes>=4.4.0",
+    "apache-airflow-providers-common-sql>=1.2.0",
     "pyyaml",
     "packaging",
 ]
@@ -52,6 +53,9 @@ common-sql = [
     "apache-airflow-providers-common-sql>=1.2.0"
 ]
 tests = [
+    "apache-airflow-providers-http>=4.0.0",
+    "apache-airflow-providers-cncf-kubernetes>=4.4.0",
+    "apache-airflow-providers-common-sql>=1.2.0",
     "apache-airflow-providers-slack",
     "pytest>=6.0",
     "pytest-cov",

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -36,7 +36,6 @@ if [ "$AIRFLOW_VERSION" = "3.0" ]; then
   uv pip install "apache-airflow>=3.0.2" --constraint /tmp/constraint.txt
 else
   uv pip install "apache-airflow==$AIRFLOW_VERSION" --constraint /tmp/constraint.txt
-  uv pip install apache-airflow-providers-cncf-kubernetes --constraint /tmp/constraint.txt
 fi;
 
 rm /tmp/constraint.txt


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/409

- Guard the import for SqlSensor, HttpOperator, HttpSensor KPO and other Kubernetes import 
- If Package is not installed, log message about it
- Add comments that will help in future cleanup if we upgrade packages
- Introduce additional installation target, dag-factory[all, kubernetes, http, common-sql]

