### PR TITLE
Improve unittests so they disregard `$AIRFLOW_HOME`

### DIFF
--- a/scripts/test/unit-cov.sh
+++ b/scripts/test/unit-cov.sh
@@ -1,4 +1,7 @@
-pytest \
+#!/bin/bash
+
+# Unset AIRFLOW_HOME to avoid using the local airflow installation
+env -u AIRFLOW_HOME pytest \
     -vv \
     --cov=dagfactory \
     --cov-report=term-missing \


### PR DESCRIPTION
Previously, when setting the `$AIRFLOW_HOME` environment variable locally, as:
```
$ export AIRFLOW_HOME=`pwd`/dev/
```

Following our documentation to run integration tests and attempting to run our unit tests:
```
$ hatch run tests.py3.10-2.10:test-cov
```

Resulted in 11 tests failing. When unsetting `$AIRFLOW_HOME`, the tests run successfully.

This PR enables our unit tests to run regardless of the system's predefined `$AIRFLOW_HOME`.