### PR TITLE
Resolve 'credential persistence through GitHub Actions artifacts' warnings from Zizmor

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -82,6 +83,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/cache@v4
         with:
@@ -153,6 +155,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/cache@v4
         with:
@@ -206,6 +209,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -249,6 +253,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -294,6 +299,8 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
The persist-credentials option in the actions/checkout action determines whether the Git credentials used to fetch the repository are left in the Git configuration after the checkout step. Setting `persist-credentials` to `true` (the default) means the credentials will remain, allowing subsequent steps in the workflow to perform authenticated Git operations without re-authentication. Setting it to false removes the credentials, which is useful for security when you don't want later steps to have access to the credentials. 

scan results from this PR: https://github.com/astronomer/dag-factory/security/code-scanning?query=is%3Aopen+pr%3A494

vs

on main:  https://github.com/astronomer/dag-factory/security/code-scanning (this will change after merging this PR, but can be compared while the PR is still open)

related: https://github.com/astronomer/oss-integrations-private/issues/156