### PR TITLE
Fix start_date, end_date dag level uses

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -246,17 +246,11 @@ class DagBuilder:
             else:
                 raise DagFactoryException("render_template_as_native_obj should be bool type!")
 
-        try:
-            # ensure that default_args dictionary contains key "start_date"
-            # with "datetime" value in specified timezone
-            if check_dict_key(dag_params["default_args"], "start_date"):
-                dag_params["default_args"]["start_date"]: datetime = utils.get_datetime(
-                    date_value=dag_params["default_args"]["start_date"],
-                    timezone=dag_params["default_args"].get("timezone", "UTC"),
-                )
-        except KeyError as err:
-            # pylint: disable=line-too-long
-            raise DagFactoryConfigException(f"{self.dag_name} config is missing start_date") from err
+        if check_dict_key(dag_params["default_args"], "start_date"):
+            dag_params["default_args"]["start_date"]: datetime = utils.get_datetime(
+                date_value=dag_params["default_args"]["start_date"],
+                timezone=dag_params["default_args"].get("timezone", "UTC"),
+            )
         return dag_params
 
     @staticmethod

--- a/tests/fixtures/invalid_dag_factory.yml
+++ b/tests/fixtures/invalid_dag_factory.yml
@@ -1,6 +1,7 @@
 default:
   default_args:
     owner: 'default_owner'
+    start_date: "205-01-01-01" # the wrong param
   max_active_runs: 1
   dagrun_timeout_sec: 600
   schedule_interval: '0 1 * * *'

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -335,12 +335,6 @@ def test_get_dag_params():
     assert actual == expected
 
 
-def test_get_dag_params_no_start_date():
-    td = dagbuilder.DagBuilder("test_dag", {}, {})
-    with pytest.raises(Exception):
-        td.get_dag_params()
-
-
 def test_adjust_general_task_params_external_sensor_arguments():
     task_params = {"execution_date_fn": "tests.utils.one_hour_ago"}
     DagBuilder.adjust_general_task_params(task_params)

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -599,7 +599,7 @@ def test_yml_dag_rendering_in_docs():
 def test_dag_level_start():
     data = """
     my_dag:
-      schedule: "0 3 * * *"
+      schedule_interval: "0 3 * * *"
       start_date: 2024-11-11
       end_date: 2025-11-11
       tasks:


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/286

This PR addresses issues related to the usage of start_date and end_date at the DAG level.

Before this PR:

- Setting start_date in default_args had no effect 
- Defining start_date or end_date directly as DAG parameters could result in errors during DAG initialisation.

After this PR:

- start_date and end_date passed via default_args are now properly recognized and applied at the DAG level.
- Errors related to setting these parameters directly on the DAG have been resolved.

```
my_dag:
      schedule: "0 3 * * *"
      start_date: 2024-11-11
      end_date: 2025-11-11
      tasks:
        task_1:
          operator: airflow.operators.bash.BashOperator
          bash_command: "echo 1"
```