### PR TITLE
Remove `schedule_interval` parameter

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -169,8 +169,13 @@ class DagBuilder:
         # If there are no default_args, add an empty dictionary
         dag_params["default_args"] = {} if "default_args" not in dag_params else dag_params["default_args"]
 
-        if utils.check_dict_key(dag_params, "schedule_interval") and dag_params["schedule_interval"] == "None":
-            dag_params["schedule_interval"] = None
+        # Convert from 'schedule_interval: str' to 'schedule: str'
+        if utils.check_dict_key(dag_params, "schedule_interval"):
+            if dag_params["schedule_interval"] == "None":
+                dag_params["schedule"] = None
+            else:
+                dag_params["schedule"] = dag_params["schedule_interval"]
+            del dag_params["schedule_interval"]
 
         # Convert from 'dagrun_timeout_sec: int' to 'dagrun_timeout: timedelta'
         if utils.check_dict_key(dag_params, "dagrun_timeout_sec"):
@@ -819,9 +824,8 @@ class DagBuilder:
             is_airflow_version_at_least_2_4 = version.parse(AIRFLOW_VERSION) >= version.parse("2.4.0")
             is_airflow_version_at_least_2_9 = version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0")
             has_schedule_attr = utils.check_dict_key(dag_params, "schedule")
-            has_schedule_interval_attr = utils.check_dict_key(dag_params, "schedule_interval")
 
-            if has_schedule_attr and not has_schedule_interval_attr and is_airflow_version_at_least_2_4:
+            if has_schedule_attr and is_airflow_version_at_least_2_4:
                 schedule: Dict[str, Any] = dag_params.get("schedule")
 
                 has_file_attr = utils.check_dict_key(schedule, "file")

--- a/docs/configuration/configuring_workflows.md
+++ b/docs/configuration/configuring_workflows.md
@@ -7,7 +7,7 @@ You can define multiple workflows within a single YAML file based on your requir
 
 - **dag_id**: Unique identifier for your DAG.
 - **default_args**: Common arguments for all tasks.
-- **schedule**/**schedule_interval**: Specifies the execution schedule.
+- **schedule**: Specifies the execution schedule.
 - **tasks**: Defines the [Airflow tasks](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/tasks.html) in your workflow.
 
 ### Example DAG Configuration

--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -10,14 +10,14 @@ default:
   default_view: tree
   max_active_runs: 1
   orientation: LR
-  schedule_interval: 0 1 * * *
+  schedule: 0 1 * * *
 example_dag:
   default_args:
     owner: custom_owner
     start_date: 2 days
   description: this is an example dag
   doc_md: '##here is a doc md string'
-  schedule_interval: 0 3 * * *
+  schedule: 0 3 * * *
   tasks:
     task_1:
       bash_command: echo 1
@@ -34,7 +34,7 @@ example_dag:
       operator: airflow.operators.bash.BashOperator
 example_dag2:
   doc_md_file_path: $PWD/tests/fixtures/mydocfile.md
-  schedule_interval: None
+  schedule: None
   tasks:
     task_1:
       bash_command: echo 1

--- a/tests/fixtures/dag_factory_http_operator_task.yml
+++ b/tests/fixtures/dag_factory_http_operator_task.yml
@@ -7,7 +7,7 @@ http_operator_example_dag:
   default_args:
     owner: "@owner"
   description: "this is an HttpOperator dag"
-  schedule_interval: "0 3 * * *"
+  schedule: "0 3 * * *"
   tags: ['http']
   render_template_as_native_obj: True
   tasks:

--- a/tests/fixtures/dag_factory_kubernetes_pod_operator.yml
+++ b/tests/fixtures/dag_factory_kubernetes_pod_operator.yml
@@ -10,7 +10,7 @@ default:
   dagrun_timeout_sec: 600
   default_view: 'tree'
   orientation: 'LR'
-  schedule_interval: '0 1 * * *'
+  schedule: '0 1 * * *'
 example_dag:
   tasks:
     task_1:

--- a/tests/fixtures/dag_factory_kubernetes_pod_operator_lt_2_7.yml
+++ b/tests/fixtures/dag_factory_kubernetes_pod_operator_lt_2_7.yml
@@ -10,7 +10,7 @@ default:
   dagrun_timeout_sec: 600
   default_view: 'tree'
   orientation: 'LR'
-  schedule_interval: '0 1 * * *'
+  schedule: '0 1 * * *'
 example_dag:
   tasks:
     task_1:

--- a/tests/fixtures/dag_factory_no_or_none_string_schedule.yml
+++ b/tests/fixtures/dag_factory_no_or_none_string_schedule.yml
@@ -24,7 +24,7 @@ example_dag_none_string_schedule:
   default_args:
     owner: custom_owner
     start_date: 2 days
-  schedule_interval: ' none    '
+  schedule: ' none    '
   description: this is an example dag
   doc_md: '##here is a doc md string'
   tasks:

--- a/tests/fixtures/dag_factory_simple_http_operator_task.yml
+++ b/tests/fixtures/dag_factory_simple_http_operator_task.yml
@@ -7,7 +7,7 @@ simple_http_operator_example_dag:
   default_args:
     owner: "@owner"
   description: "this is a SimpleHttpOperator dag"
-  schedule_interval: "0 3 * * *"
+  schedule: "0 3 * * *"
   tags: ['http']
   render_template_as_native_obj: True
   tasks:

--- a/tests/fixtures/dag_factory_task_group.yml
+++ b/tests/fixtures/dag_factory_task_group.yml
@@ -8,7 +8,7 @@ default:
   default_view: tree
   max_active_runs: 1
   orientation: LR
-  schedule_interval: 0 1 * * *
+  schedule: 0 1 * * *
 example_dag:
   description: "this dag uses task groups"
   task_groups:

--- a/tests/fixtures/dag_factory_variables_as_arguments.yml
+++ b/tests/fixtures/dag_factory_variables_as_arguments.yml
@@ -10,14 +10,14 @@ default:
   dagrun_timeout_sec: 600
   default_view: 'tree'
   orientation: 'LR'
-  schedule_interval: '0 1 * * *'
+  schedule: '0 1 * * *'
 
 example_dag:
   default_args:
     owner: 'custom_owner'
     start_date: 2 days
   description: 'this is an example dag'
-  schedule_interval: '0 3 * * *'
+  schedule: '0 3 * * *'
   tasks:
     task_1:
       operator: airflow.operators.bash.BashOperator
@@ -39,7 +39,7 @@ second_example_dag:
     owner: 'custom_owner'
     start_date: 3 days
   description: 'this is a second example dag'
-  schedule_interval: '0 6 * * *'
+  schedule: '0 6 * * *'
   tasks:
     task_0:
       operator: airflow.operators.bash.BashOperator

--- a/tests/fixtures/dag_md_docs.yml
+++ b/tests/fixtures/dag_md_docs.yml
@@ -10,10 +10,10 @@ default:
   default_view: tree
   max_active_runs: 1
   orientation: LR
-  schedule_interval: 0 1 * * *
+  schedule: 0 1 * * *
 
 example_dag2:
-  schedule_interval: None
+  schedule: None
   tasks:
     task_1:
       bash_command: echo 1

--- a/tests/fixtures/invalid_dag_factory.yml
+++ b/tests/fixtures/invalid_dag_factory.yml
@@ -3,13 +3,13 @@ default:
     owner: 'default_owner'
   max_active_runs: 1
   dagrun_timeout_sec: 600
-  schedule_interval: '0 1 * * *'
+  schedule: '0 1 * * *'
 
 example_dag:
   default_args:
     owner: 'custom_owner'
   description: 'this is an example dag'
-  schedule_interval: '0 3 * * *'
+  schedule: '0 3 * * *'
   tasks:
     task_1:
       operator: airflow.operators.bash.BashOperator

--- a/tests/fixtures/invalid_yaml.yml
+++ b/tests/fixtures/invalid_yaml.yml
@@ -3,14 +3,14 @@ default:
     owner: 'default_owner'
     start_date: 2018-03-01
   max_active_runs: 1
-  schedule_interval: '0 1 * * *'
+  schedule: '0 1 * * *'
 
 example_dag:
   default_args:
     owner: 'custom_owner'
     start_date: 2 days
   description: 'this is an example dag'
-  schedule_interval: '0 3 * * *'
+  schedule: '0 3 * * *'
   tasks:
     task_1
       operator: airflow.operators.bash.BashOperator

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -381,11 +381,11 @@ default:
   default_view: tree
   max_active_runs: 1
   orientation: LR
-  schedule_interval: 0 1 * * *
+  schedule: 0 1 * * *
 
 example_dag2:
   doc_md_file_path: {DOC_MD_FIXTURE_FILE}
-  schedule_interval: None
+  schedule: None
   tasks:
     task_1:
       bash_command: echo 1
@@ -418,40 +418,31 @@ def test_doc_md_callable():
     assert str(td.get_dag_configs()["example_dag3"]["doc_md_python_arguments"]) in expected_doc_md
 
 
-def test_schedule_interval():
+def test_schedule():
     td = dagfactory.DagFactory(TEST_DAG_FACTORY)
     td.generate_dags(globals())
-    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-        schedule_interval = globals()["example_dag2"].schedule_interval
-        expected_schedule_interval = datetime.timedelta(days=1)
-    else:
-        schedule_interval = globals()["example_dag2"].schedule
-        expected_schedule_interval = None
-    assert schedule_interval == expected_schedule_interval
+    # Since we now convert schedule_interval to schedule, we should always use schedule
+    schedule = globals()["example_dag2"].schedule
+    expected_schedule = None  # example_dag2 has schedule: None
+    assert schedule == expected_schedule
 
 
 def test_no_schedule_supplied():
     td = dagfactory.DagFactory(DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE)
     td.generate_dags(globals())
-    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-        schedule_interval = globals()["example_dag_no_schedule"].schedule_interval
-        expected_schedule_interval = datetime.timedelta(days=1)
-    else:
-        schedule_interval = globals()["example_dag_no_schedule"].schedule
-        expected_schedule_interval = None
-    assert schedule_interval == expected_schedule_interval
+    # Since we now convert schedule_interval to schedule, we should always use schedule
+    schedule = globals()["example_dag_no_schedule"].schedule
+    expected_schedule = datetime.timedelta(days=1)  # default from default config
+    assert schedule == expected_schedule
 
 
 def test_none_string_schedule_supplied():
     td = dagfactory.DagFactory(DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE)
     td.generate_dags(globals())
-    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-        schedule_interval = globals()["example_dag_none_string_schedule"].schedule_interval
-        expected_schedule_interval = datetime.timedelta(days=1)
-    else:
-        schedule_interval = globals()["example_dag_none_string_schedule"].schedule
-        expected_schedule_interval = None
-    assert schedule_interval == expected_schedule_interval
+    # Since we now convert schedule_interval to schedule, we should always use schedule
+    schedule = globals()["example_dag_none_string_schedule"].schedule
+    expected_schedule = None  # " none    " gets converted to None
+    assert schedule == expected_schedule
 
 
 def test_dagfactory_dict():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -190,11 +190,7 @@ def get_http_sensor_path():
 
 
 def get_schedule_key():
-    airflow_version = version.parse(AIRFLOW_VERSION)
-    if airflow_version < version.parse("3.0.0"):
-        return "schedule_interval"
-    else:
-        return "schedule"
+    return "schedule"
 
 
 def get_bash_operator_path():


### PR DESCRIPTION
This PR refactors the usage of the deprecated `schedule_interval` parameter and replaces it with the `schedule` parameter.

This is my first pull request in this project!
If there’s anything I can improve or adjust, I’d really appreciate your feedback.

resolves #454 