### PR TITLE
Change  `DagFactory` class access to private 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 
-- Airflow providers are now optional dependencies by @pankajastro in [#486](https://github.com/astronomer/dag-factory/pull/486) Previously, `dag-factory` enforced installation of `apache-airflow-providers-http` and `apache-airflow-providers-cncf-kubernetes`. These are now optional. If your DAGs depend on these providers, you must install them manually in your environment. Alternatively, you can install dag-factory with extras like `dag-factory[all]`, `dag-factory[kubernetes]`, etc.
-- Removed clean_dags function by @pankajastro in [#498](https://github.com/astronomer/dag-factory/pull/498) You no longer need to call `example_dag_factory.clean_dags(globals())` in your DAG files. DAG cleanup is now controlled via the Airflow config setting `AIRFLOW__DAG_PROCESSOR__REFRESH_INTERVAL`.
+- Airflow providers are now optional dependencies by @pankajastro in [#486](https://github.com/astronomer/dag-factory/pull/486)
+  - Previously, `dag-factory` enforced the installation of `apache-airflow-providers-http` and `apache-airflow-providers-cncf-kubernetes`. These Airflow providers dependencies are now optional. If your DAGs depend on these providers, you must install them manually. Alternatively, you can install `dag-factory` with extras like `dag-factory[all]`, `dag-factory[kubernetes]`, etc.
+- Removed clean_dags function by @pankajastro in [#498](https://github.com/astronomer/dag-factory/pull/498)
+  - You no longer need to call `example_dag_factory.clean_dags(globals())` in your DAG files. DAG cleanup is now controlled via the Airflow config setting `AIRFLOW__DAG_PROCESSOR__REFRESH_INTERVAL`.
 - Remove custom typecasting for timedelta by @pankajastro in [#512](https://github.com/astronomer/dag-factory/pull/512).
   - Removed `dagrun_timeout_sec` from dag param.
   - Removed `retry_delay_sec`, `sla_secs` and `execution_timeout` from `default_args`.
   - Removed `execution_timeout_secs` `sla_secs` and `execution_delta_secs` from task param.
+- Make `generate_dags` method of `DagFactory` class private i.e `_generate_dags` by @pankajastro in [#509](https://github.com/astronomer/dag-factory/pull/509)
+  - The `_generate_dags(...)` method is now limited to internal use only. Users are encouraged to migrate to `load_yaml_dags(...)` interface
+  - Removed Import Path `from dagfactory import DagFactory`
 
 ## [0.23.0] - 2025-07-14
 

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -1,9 +1,8 @@
 """Modules and methods to export for easier access"""
 
-from .dagfactory import DagFactory, load_yaml_dags
+from .dagfactory import load_yaml_dags
 
 __version__ = "0.23.0"
 __all__ = [
-    "DagFactory",
     "load_yaml_dags",
 ]

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -23,7 +23,7 @@ from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
 SYSTEM_PARAMS: List[str] = ["default", "task_groups"]
 
 
-class DagFactory:
+class _DagFactory:
     """
     Takes a YAML config or a python dictionary and generates DAGs.
 
@@ -49,7 +49,7 @@ class DagFactory:
         assert bool(config_filepath) ^ bool(config), "Either `config_filepath` or `config` should be provided"
 
         if config_filepath:
-            DagFactory._validate_config_filepath(config_filepath=config_filepath)
+            _DagFactory._validate_config_filepath(config_filepath=config_filepath)
             self.config: Dict[str, Any] = self._load_dag_config(config_filepath=config_filepath)
         if config:
             self.config = config
@@ -304,10 +304,10 @@ def load_yaml_dags(
     candidate_dag_files = []
 
     if config_filepath:
-        factory = DagFactory(config_filepath=config_filepath, default_args_config_path=default_args_config_path)
+        factory = _DagFactory(config_filepath=config_filepath, default_args_config_path=default_args_config_path)
         factory._generate_dags(globals_dict)
     elif config_dict:
-        factory = DagFactory(config=config_dict, default_args_config_dict=default_args_config_dict)
+        factory = _DagFactory(config=config_dict, default_args_config_dict=default_args_config_dict)
         factory._generate_dags(globals_dict)
     else:
         for suf in suffix:
@@ -316,7 +316,7 @@ def load_yaml_dags(
             config_file_abs_path = str(config_file_path.absolute())
             logging.info("Loading %s", config_file_abs_path)
             try:
-                factory = DagFactory(config_file_abs_path, default_args_config_path=default_args_config_path)
+                factory = _DagFactory(config_file_abs_path, default_args_config_path=default_args_config_path)
                 factory._generate_dags(globals_dict)
             except Exception:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -195,9 +195,7 @@ class DagFactory:
 
         :returns: dict from YAML config file
         """
-        # pylint: disable=consider-using-with
-        config = load_yaml_file(config_filepath)
-        return config
+        return load_yaml_file(config_filepath)
 
     def get_dag_configs(self) -> Dict[str, Dict[str, Any]]:
         """
@@ -262,7 +260,7 @@ class DagFactory:
         for dag_id, dag in dags.items():
             globals[dag_id]: DAG = dag
 
-    def generate_dags(self, globals: Dict[str, Any]) -> None:
+    def _generate_dags(self, globals: Dict[str, Any]) -> None:
         """
         Generates DAGs from YAML config
 
@@ -277,10 +275,13 @@ def load_yaml_dags(
     globals_dict: Dict[str, Any],
     dags_folder: str = airflow_conf.get("core", "dags_folder"),
     default_args_config_path: str = airflow_conf.get("core", "dags_folder"),
+    config_filepath: Optional[str] = None,
+    config_dict: Optional[dict] = None,
+    default_args_config_dict: Optional[dict] = None,
     suffix=None,
 ):
     """
-    Loads all the yaml/yml files in the dags folder
+    Loads YAML or YML files in a specified folder (or from a specific YAML file or dictionary)
 
     The dags folder is defaulted to the airflow dags folder if unspecified.
     And the prefix is set to yaml/yml by default. However, it can be
@@ -289,22 +290,35 @@ def load_yaml_dags(
     :param globals_dict: The globals() from the file used to generate DAGs
     :param dags_folder: Path to the folder you want to get recursively scanned
     :param default_args_config_path: The Folder path where defaults.yml exist.
+    :param config_filepath: A YAML path for DAG config.
+    :param config_dict: The DAG dictionary.
+    :param default_args_config_dict: The dictionary that hold default value.
     :param suffix: file suffix to filter `in` what files to scan for dags
     """
+    # TODO: Support ignoring yml files in load_yaml_dags
+    # https://github.com/astronomer/dag-factory/issues/527
     # chain all file suffixes in a single iterator
     logging.info("Loading DAGs from %s", dags_folder)
     if suffix is None:
         suffix = [".yaml", ".yml"]
     candidate_dag_files = []
-    for suf in suffix:
-        candidate_dag_files = list(chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")))
-    for config_file_path in candidate_dag_files:
-        config_file_abs_path = str(config_file_path.absolute())
-        logging.info("Loading %s", config_file_abs_path)
-        try:
-            factory = DagFactory(config_file_abs_path, default_args_config_path=default_args_config_path)
-            factory.generate_dags(globals_dict)
-        except Exception:  # pylint: disable=broad-except
-            logging.exception("Failed to load dag from %s", config_file_path)
-        else:
-            logging.info("DAG loaded: %s", config_file_path)
+
+    if config_filepath:
+        factory = DagFactory(config_filepath=config_filepath, default_args_config_path=default_args_config_path)
+        factory._generate_dags(globals_dict)
+    elif config_dict:
+        factory = DagFactory(config=config_dict, default_args_config_dict=default_args_config_dict)
+        factory._generate_dags(globals_dict)
+    else:
+        for suf in suffix:
+            candidate_dag_files = list(chain(candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")))
+        for config_file_path in candidate_dag_files:
+            config_file_abs_path = str(config_file_path.absolute())
+            logging.info("Loading %s", config_file_abs_path)
+            try:
+                factory = DagFactory(config_file_abs_path, default_args_config_path=default_args_config_path)
+                factory._generate_dags(globals_dict)
+            except Exception:  # pylint: disable=broad-except
+                logging.exception("Failed to load dag from %s", config_file_path)
+            else:
+                logging.info("DAG loaded: %s", config_file_path)

--- a/dev/dags/asset_triggered_dags.py
+++ b/dev/dags/asset_triggered_dags.py
@@ -3,14 +3,14 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "asset_triggered_dags.yml")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
-
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/datasets/example_dag_datasets.py
+++ b/dev/dags/datasets/example_dag_datasets.py
@@ -3,14 +3,14 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "datasets/example_dag_datasets.yml")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
-
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/example_callbacks.py
+++ b/dev/dags/example_callbacks.py
@@ -3,14 +3,15 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_callbacks.yml")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
 
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/example_dag_factory.py
+++ b/dev/dags/example_dag_factory.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 
@@ -11,7 +11,7 @@ CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_dag_factory.yml")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
-
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/example_dag_factory_default_config_dict.py
+++ b/dev/dags/example_dag_factory_default_config_dict.py
@@ -1,18 +1,30 @@
-import os
-from pathlib import Path
-
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
-DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
-CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
+daily_etl = {
+    "daily_etl": {
+        "schedule": "@daily",
+        "tasks": [
+            {"task_id": "extract", "operator": "airflow.operators.bash.BashOperator", "bash_command": "echo extract"},
+            {
+                "task_id": "transform",
+                "operator": "airflow.operators.bash.BashOperator",
+                "bash_command": "echo transform",
+                "dependencies": ["extract"],
+            },
+            {
+                "task_id": "load",
+                "operator": "airflow.operators.bash.BashOperator",
+                "bash_command": "echo load",
+                "dependencies": ["transform"],
+            },
+        ],
+    }
+}
 
-config_file = str(CONFIG_ROOT_DIR / "example_dag_factory_default_config_dict.yml")
-
-example_dag_factory = dagfactory.DagFactory(
-    config_file, default_args_config_dict={"default_args": {"start_date": "2025-01-01", "owner": "global_owner"}}
+load_yaml_dags(
+    globals_dict=globals(),
+    config_dict=daily_etl,
+    default_args_config_dict={"default_args": {"start_date": "2025-01-01", "owner": "global_owner"}},
 )
-
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())

--- a/dev/dags/example_http_operator_task.py
+++ b/dev/dags/example_http_operator_task.py
@@ -19,7 +19,7 @@ except ImportError:
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 
@@ -31,7 +31,8 @@ elif SIMPLE_HTTP_OPERATOR_AVAILABLE:
 else:
     raise ImportError("Package apache-airflow-providers-http is not installed.")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
 
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/example_map_index_template.py
+++ b/dev/dags/example_map_index_template.py
@@ -3,13 +3,15 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_map_index_template.yml")
-example_dag_factory = dagfactory.DagFactory(config_file)
 
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/dev/dags/example_object_storage.py
+++ b/dev/dags/example_object_storage.py
@@ -3,13 +3,14 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_object_storage.yml")
-example_dag_factory = dagfactory.DagFactory(config_file)
 
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    dags_folder=config_file,
+)

--- a/dev/dags/kpo.py
+++ b/dev/dags/kpo.py
@@ -3,13 +3,13 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
 CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "kpo.yml")
-example_dag_factory = dagfactory.DagFactory(config_file)
-
-# Creating task dependencies
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/docs/configuration/defaults.md
+++ b/docs/configuration/defaults.md
@@ -132,9 +132,9 @@ sample_project
 Assuming you instantiate the DAG by using:
 
 ```python
-DagFactory(
+load_yaml_dags(
    "a/b/c/some_dags.yml",
-   default_args_config_path="a"
+   default_args_config_path=default_args_config_path="a"
 )`
 
 The DAG will be using the default configuration defined in all the following files:

--- a/docs/configuration/load_yaml_dags.md
+++ b/docs/configuration/load_yaml_dags.md
@@ -1,0 +1,65 @@
+# load_yaml_dags Function
+
+The `load_yaml_dags` function is responsible for loading DAG configurations from YAML or YML files in a specified folder (or from a specific YAML file or dictionary). It parses the files or dictionary and generates Airflow DAGs by utilizing the provided globals_dict.
+
+## Example Usage
+
+### 1. Loading from YAML Files in a Folder
+
+```python
+from dagfactory import load_yaml_dags
+
+# Load DAGs from a folder, e.g., /path/to/dags
+load_yaml_dags(globals_dict=globals(), dags_folder='/path/to/your/dags')
+```
+
+### 2. Loading from a Specific YAML File
+
+```python
+from dagfactory import load_yaml_dags
+
+# Load DAG from a specific YAML file
+load_yaml_dags(globals_dict=globals(), config_filepath='/path/to/your/dag_config.yaml')
+
+```
+
+### 3. Loading from YAML File with default_args_config_path
+
+```python
+from dagfactory import load_yaml_dags
+
+# Load a single DAG from a YAML file with custom default arguments config path
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath='/path/to/your/dag_config.yaml',
+    default_args_config_path='/path/to/your/default_args.yml'
+)
+```
+
+### 4. Loading from a Dictionary
+
+```python
+from dagfactory import load_yaml_dags
+
+# Load DAG from a dictionary configuration
+dag_config_dict = {
+    # Your DAG configuration here
+}
+load_yaml_dags(globals_dict=globals(), config_dict=dag_config_dict)
+```
+
+### 5. Loading from a Dictionary with default_args_config_dict
+
+```python
+from dagfactory import load_yaml_dags
+
+# Load DAGs with custom default arguments from a dictionary
+default_args_dict = {
+    # Your default arguments
+}
+
+dag_config_dict = {
+     # Your DAG configuration here
+}
+load_yaml_dags(globals_dict=globals(), config_dict=dag_config_dict, default_args_config_dict=default_args_dict)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Astro CLI: getting-started/quick-start-astro-cli.md
   - Configuration:
       - configuration/configuring_workflows.md
+      - configuration/load_yaml_dags.md
       - configuration/environment_variables.md
       - configuration/defaults.md
       - configuration/params.md

--- a/scripts/airflow3/dags/example_dag_factory.py
+++ b/scripts/airflow3/dags/example_dag_factory.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 # The following import is here so Airflow parses this file
 # from airflow import DAG
-import dagfactory
+from dagfactory import load_yaml_dags
 
 DEFAULT_CONFIG_ROOT_DIR = os.getenv("DEFAULT_CONFIG_ROOT_DIR", "/usr/local/airflow/dags/")
 
@@ -11,8 +11,7 @@ CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_dag_factory.yml")
 
-example_dag_factory = dagfactory.DagFactory(config_file)
-
-# Creating task dependencies
-example_dag_factory.clean_dags(globals())
-example_dag_factory.generate_dags(globals())
+load_yaml_dags(
+    globals_dict=globals(),
+    config_filepath=config_file,
+)

--- a/tests/test_dagbuilder_httpoperator.py
+++ b/tests/test_dagbuilder_httpoperator.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pendulum
 import pytest
 
+from dagfactory import load_yaml_dags
+
 try:
     from airflow.sdk.definitions.dag import DAG  # noqa: F401
 except ImportError:
@@ -237,7 +239,6 @@ def test_dag_with_http_operator():
 @pytest.mark.skipif(HTTP_OPERATOR_CLASS is None, reason=HTTP_OPERATOR_UNAVAILABLE_MSG)
 def test_http_operator_from_yaml():
     """Test loading HTTP operator from a fixture YAML file"""
-    from dagfactory import DagFactory
 
     # Select the appropriate fixture based on which operator is available
     if HTTP_OPERATOR_PATH == "airflow.providers.http.operators.http.HttpOperator":
@@ -251,12 +252,12 @@ def test_http_operator_from_yaml():
     if not os.path.exists(fixture_path):
         pytest.skip(f"Test fixture not found: {fixture_path}")
 
-    # Create DagFactory with fixture and build DAGs
-    dag_factory = DagFactory(fixture_path)
-    dags = {}
+    load_yaml_dags(
+        globals_dict=globals(),
+        config_filepath=fixture_path,
+    )
 
-    # Call generate_dags to build all DAGs from the YAML file
-    dag_factory.generate_dags(dags)
+    dags = globals()
 
     # Now check if our DAG is in the result
     dag = dags.get(dag_id)

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -23,7 +23,7 @@ from tests.utils import get_bash_operator_path
 
 here = os.path.dirname(__file__)
 
-from dagfactory import dagfactory, exceptions, load_yaml_dags
+from dagfactory import dagfactory, load_yaml_dags
 
 TEST_DAG_FACTORY = os.path.join(here, "fixtures/dag_factory.yml")
 DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE = os.path.join(here, "fixtures/dag_factory_no_or_none_string_schedule.yml")
@@ -474,41 +474,6 @@ def test_none_string_schedule_supplied():
     schedule = _get_schedule_value("example_dag_none_string_schedule")
     expected_schedule = None
     assert schedule == expected_schedule
-
-
-def test_schedule_interval_supplied():
-    td = dagfactory.DagFactory(DAG_FACTORY_SCHEDULE_INTERVAL)
-    with pytest.raises(
-        exceptions.DagFactoryException,
-        match="The `schedule_interval` key is no longer supported in Airflow 3\\.0\\+\\. Use `schedule` instead\\.",
-    ):
-        td._generate_dags(globals())
-
-def test_schedule_interval():
-    load_yaml_dags(
-        globals_dict=globals(),
-        config_filepath=TEST_DAG_FACTORY,
-    )
-    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-        schedule_interval = globals()["example_dag2"].schedule_interval
-        expected_schedule_interval = datetime.timedelta(days=1)
-    else:
-        schedule_interval = globals()["example_dag2"].schedule
-        expected_schedule_interval = None
-    assert schedule_interval == expected_schedule_interval
-
-def test_no_schedule_supplied():
-    load_yaml_dags(
-        globals_dict=globals(),
-        config_filepath=DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE,
-    )
-    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-        schedule_interval = globals()["example_dag_no_schedule"].schedule_interval
-        expected_schedule_interval = datetime.timedelta(days=1)
-    else:
-        schedule_interval = globals()["example_dag_no_schedule"].schedule
-        expected_schedule_interval = None
-    assert schedule_interval == expected_schedule_interval
 
 
 def test_dagfactory_dict():


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/472

This PR disable the below interface to create a DAG with DAG-Factory
```python3
import dagfactory

example_dag_factory = dagfactory.DagFactory("path/to/config.yml")

# Creating task dependencies
example_dag_factory.generate_dags(globals())
```
Additionally, it unifies the interface into a single method for DAG creation with DAG-Factory

```python3
from dagfactory import load_yaml_dags

load_yaml_dags(
    globals_dict=globals(),
   ...
)
```

Previously, `load_yaml_dags(...)` only accepted a folder as the configuration input. This PR introduces the following parameters to support handling a single configuration file and dict input:

- config_filepath
- config_dict
- default_args_config_dict

The order in which these parameters will apply is as follows:

- If config_filepath is provided, config_filepath and default_args_config_filepath will be used.
- If config_dict is provided, config_dict and default_args_config_dict will be used.
- If neither of the above is provided, the function will iterate over dags_folder and render all DAGs (The current main behaviour if `load_dags(...)`)

Example for passing single yaml file
```python3
import os
from pathlib import Path

# The following import is here so Airflow parses this file
# from airflow import DAG
from dagfactory import load_yaml_dags

DEFAULT_CONFIG_ROOT_DIR = "/usr/local/airflow/dags/"
CONFIG_ROOT_DIR = Path(os.getenv("CONFIG_ROOT_DIR", DEFAULT_CONFIG_ROOT_DIR))

config_file = str(CONFIG_ROOT_DIR / "example_callbacks.yml")


load_yaml_dags(
    globals_dict=globals(),
    config_filepath=config_file,
)
```

Removed the import path

```python3
from dagfactory import DagFactory
```
