### PR TITLE
Introduce DAG Factory CLI

### DIFF
--- a/dagfactory/__main__.py
+++ b/dagfactory/__main__.py
@@ -1,0 +1,44 @@
+import typer
+from rich.console import Console
+
+from . import __version__
+
+DESCRIPTION = """
+[bold][medium_purple3]DAG Factory[/medium_purple3][/bold]: Dynamically build Apache Airflow DAGs from YAML files
+
+Find out more at: https://github.com/astronomer/dagfactory
+"""
+
+
+console = Console()
+
+
+app = typer.Typer(
+    name="dagfactory",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="Show the version and exit.",
+        is_eager=True,  # Display version immediately before parsing other options
+    ),
+):
+    if version:
+        console.print(f"DAG Factory {__version__}")
+        raise typer.Exit()
+
+    if ctx.invoked_subcommand is None:
+        console.print(DESCRIPTION)
+        typer.echo(ctx.get_help())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,11 @@ dependencies = [
     "apache-airflow>=2.4",
     "pyyaml",
     "packaging",
+    "typer"
 ]
+
+[project.scripts]
+dagfactory = "dagfactory.__main__:app"
 
 
 [project.optional-dependencies]

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,0 +1,30 @@
+from typer.testing import CliRunner
+
+from dagfactory import __version__
+from dagfactory.__main__ import app
+
+runner = CliRunner()
+
+
+def test_version_option():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"DAG Factory {__version__}" in result.output
+
+    result_short = runner.invoke(app, ["-v"])
+    assert result_short.exit_code == 0
+    assert f"DAG Factory {__version__}" in result_short.output
+
+
+def test_help_output_when_no_command():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "DAG Factory" in result.output
+    assert "--help" in result.output
+
+
+def test_help_option():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage" in result.output
+    assert "Show the version and exit" in result.output

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -20,7 +20,7 @@ def test_help_output_when_no_command():
     result = runner.invoke(app, [])
     assert result.exit_code == 0
     assert "DAG Factory" in result.output
-    assert "--help" in result.output
+    assert "dagfactory [OPTIONS] COMMAND [ARGS]" in result.output
 
 
 def test_help_option():


### PR DESCRIPTION
Introduce a CLI for DAG Factory, with the following features:
* help
* version

The proposal is that we use Rich for formatting the terminal output since it is good for:
* Pretty-printing text, markdown, JSON, tracebacks.
* Adding color, emojis, tables, progress bars, syntax highlighting.
* Improving readability and user experience of any CLI.

And that we use Typer, which helps build CLIs using type hints - on top of Click. It is good for:
* Rapidly building CLIs with minimal boilerplate.
* Leveraging type hints for arguments, validation, and help text.
* Auto-generating CLI docs and help messages.
* Getting all of Click’s power with less code.

It is not sas customizable as Click for complex CLI structures, but this should not be an issue given the features we're planning for the DAG Factory CLI.

The documentation was added in a separate PR: #511

Relates to: #445

**Screenshots**

Main command:
<img width="833" height="238" alt="Screenshot 2025-07-28 at 14 59 08" src="https://github.com/user-attachments/assets/8302438b-e709-4497-84ca-3f530133d5eb" />

Version:
<img width="563" height="38" alt="Screenshot 2025-07-28 at 14 59 24" src="https://github.com/user-attachments/assets/af3316e6-2645-4ecc-9054-11cd73c46133" />

Help:
<img width="818" height="158" alt="Screenshot 2025-07-28 at 14 59 41" src="https://github.com/user-attachments/assets/473cf84c-60cc-4bfb-89c7-60b91652dabe" />
