### PR TITLE
Add CLI `lint` command

### DIFF
--- a/dagfactory/__main__.py
+++ b/dagfactory/__main__.py
@@ -1,7 +1,13 @@
-import typer
-from rich.console import Console
+from pathlib import Path
 
-from . import __version__
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from dagfactory import __version__
+from dagfactory._yaml import load_yaml_file
 
 DESCRIPTION = """
 [bold][medium_purple3]DAG Factory[/medium_purple3][/bold]: Dynamically build Apache Airflow DAGs from YAML files
@@ -18,6 +24,23 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     invoke_without_command=True,
 )
+
+
+def check_yaml_syntax(file_path: Path):
+    """
+    Check if the YAML file is valid.
+    """
+    try:
+        load_yaml_file(file_path)
+    except yaml.YAMLError as e:
+        return str(e)
+
+
+def find_yaml_files(directory: Path):
+    """
+    Find all YAML files in the directory.
+    """
+    return list(directory.rglob("*.yaml")) + list(directory.rglob("*.yml"))
 
 
 @app.callback()
@@ -38,6 +61,50 @@ def main(
     if ctx.invoked_subcommand is None:
         console.print(DESCRIPTION)
         typer.echo(ctx.get_help())
+
+
+@app.command()
+def lint(
+    path: Path = typer.Argument(..., help="Path to a directory containing YAML files or to a YAML file to lint"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show full error messages"),
+):
+    """Scan YAML files for syntax errors."""
+    if not path.exists():
+        console.print(f"[red]Error:[/red] Path '{path}' does not exist.")
+        raise typer.Exit(1)
+
+    if path.is_dir():
+        files = find_yaml_files(path)
+    else:
+        files = [path]
+
+    if not files:
+        console.print(f"[yellow]No YAML files found in '{path}'.[/yellow]")
+        raise typer.Exit()
+
+    table = Table(title="[bold][medium_purple3]DAG Factory[/medium_purple3][/bold]: YAML Lint Results", show_lines=True)
+    table.add_column("File", style="cyan", no_wrap=True)
+    table.add_column("Status", style="bold")
+    table.add_column("Error Message", style="red", no_wrap=False, overflow="fold")
+
+    total_errors = 0
+    for file_path in files:
+        error = check_yaml_syntax(file_path)
+        if error:
+            total_errors += 1
+            message = error.strip() if verbose else error.strip().split("\n")[0][:120] + "..."
+            table.add_row(str(file_path), Text("Syntax Error", style="red"), Text(message, style="red"))
+        else:
+            table.add_row(str(file_path), Text("OK", style="green"), "")
+
+    console.print(table)
+    if total_errors > 0:
+        console.print(f"Analysed {len(files)} files, found [red]{total_errors}[/red] invalid YAML files.")
+        if not verbose:
+            console.print(f"For more details on the errors, run with --verbose.")
+        raise typer.Exit(1)
+    else:
+        console.print(f"Analysed {len(files)} files, [green]no errors found.[/green]")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/dagfactory/__main__.py
+++ b/dagfactory/__main__.py
@@ -49,7 +49,6 @@ def main(
     version: bool = typer.Option(
         None,
         "--version",
-        "-v",
         help="Show the version and exit.",
         is_eager=True,  # Display version immediately before parsing other options
     ),

--- a/dagfactory/_yaml.py
+++ b/dagfactory/_yaml.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+
+import yaml
+
+from .utils import cast_with_type
+
+
+def load_yaml_file(file_path: str) -> dict[str, any]:
+    """
+    Load a YAML file into a dictionary.
+    """
+
+    def __join(loader: yaml.FullLoader, node: yaml.Node) -> str:
+        seq = loader.construct_sequence(node)
+        return "".join([str(i) for i in seq])
+
+    def __or(loader: yaml.FullLoader, node: yaml.Node) -> str:
+        seq = loader.construct_sequence(node)
+        return " | ".join([f"({str(i)})" for i in seq])
+
+    def __and(loader: yaml.FullLoader, node: yaml.Node) -> str:
+        seq = loader.construct_sequence(node)
+        return " & ".join([f"({str(i)})" for i in seq])
+
+    yaml.add_constructor("!join", __join, yaml.FullLoader)
+    yaml.add_constructor("!or", __or, yaml.FullLoader)
+    yaml.add_constructor("!and", __and, yaml.FullLoader)
+
+    with open(file_path, "r", encoding="utf-8") as fp:
+        config_with_env = os.path.expandvars(fp.read())
+        config: dict[str, any] = yaml.load(stream=config_with_env, Loader=yaml.FullLoader)
+        config = cast_with_type(config)
+
+    return config

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -2,18 +2,62 @@
 
 After installing DAG Factory, the CLI can be invoked using the `dagfactory` command.
 
-## Usage
+## Commands summary
+
+| Command | Args   | Flags       | Description                                          |
+| ------- | ------ | ----------- | ---------------------------------------------------- |
+| `lint`  | `path` | `--verbose` | Check if the given directory or file is a valid YAML |
+
+For more details about the available commands, run `dagfactory --help`.
+
+### Example
+
+```bash
+ dagfactory lint some/dir --verbose
+```
+
+Output:
+
+```bash
+                           DAG Factory: YAML Lint Results
+┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ File                 ┃ Status       ┃ Error Message                               ┃
+┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ some/dir/v.yml       │ OK           │                                             │
+├──────────────────────┼────────------┼---------------------------------────────────┤
+│ some/dir/b.yaml      │ Syntax Error │ mapping values are not allowed here         │
+│                      │              │   in "<unicode string>", line 2, column 7:  │
+│                      │              │       host: localhost                       │
+│                      │              │           ^                                 │
+├──────────────────────┼──────────────┼─────────────────────────────────────────────┤
+│ some/dir/a.yml       │ Syntax Error │ while parsing a flow sequence               │
+│                      │              │   in "<unicode string>", line 2, column 5:  │
+│                      │              │       - [orange, mango                      │
+│                      │              │         ^                                   │
+│                      │              │ expected ',' or ']', but got '<stream end>' │
+│                      │              │   in "<unicode string>", line 3, column 1:  │
+│                      │              │                                             │
+│                      │              │     ^                                       │
+└──────────────────────┴──────────────┴─────────────────────────────────────────────┘
+Analysed 3 files, found 2 invalid YAML files.
+```
+
+### Flags
+
+## Base command usage
 
 ```bash
 dagfactory [OPTIONS]
 ```
 
-| Option      | Alias | Description                                        |
+### Flags
+
+| Flag        | Alias | Description                                        |
 | ----------- | ----- | -------------------------------------------------- |
-| `--version` | `-v`  | Show the installed version of DAG Factory and exit |
+| `--version` |       | Show the installed version of DAG Factory and exit |
 | `--help`    | `-h`  | Show this message and exit                         |
 
-## Version
+### Version
 
 Display the DAG Factory version:
 
@@ -27,7 +71,7 @@ Output:
 DAG Factory 1.0.0a1
 ```
 
-## Help
+### Help
 
 Find out more about the DAG Factory command line:
 
@@ -45,5 +89,4 @@ DAG Factory: Dynamically build Apache Airflow DAGs from YAML files
 Options:
   -v, --version  Show the version and exit.
   -h, --help     Show this message and exit.
-
 ```

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,9 +1,26 @@
+from unittest.mock import patch
+
+import pytest
 from typer.testing import CliRunner
 
 from dagfactory import __version__
 from dagfactory.__main__ import app
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def tmp_yaml_file(tmp_path):
+    file_path = tmp_path / "valid.yaml"
+    file_path.write_text("key: value\n")
+    return file_path
+
+
+@pytest.fixture
+def tmp_invalid_yaml_file(tmp_path):
+    file_path = tmp_path / "invalid.yaml"
+    file_path.write_text("key: [unclosed\n")
+    return file_path
 
 
 def test_version_option():
@@ -28,3 +45,46 @@ def test_help_option():
     assert result.exit_code == 0
     assert "Usage" in result.output
     assert "Show the version and exit" in result.output
+
+
+def test_lint_path_not_exist():
+    result = runner.invoke(app, ["lint", "nonexistent.yaml"])
+    assert result.exit_code != 0
+    assert "does not exist" in result.stdout
+
+
+def test_lint_no_yaml_files(tmp_path):
+    (tmp_path / "not_yaml.txt").write_text("hello")
+    result = runner.invoke(app, ["lint", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No YAML files found" in result.stdout
+
+
+def test_lint_valid_yaml(tmp_yaml_file):
+    result = runner.invoke(app, ["lint", str(tmp_yaml_file)])
+    assert result.exit_code == 0
+    assert "no errors found" in result.stdout.lower()
+
+
+@patch("dagfactory.__main__.Table.add_row")
+def test_lint_invalid_yaml(mock_add_row, tmp_invalid_yaml_file):
+    result = runner.invoke(app, ["lint", str(tmp_invalid_yaml_file)])
+    assert result.exit_code == 1
+    row = mock_add_row.call_args[0]
+    assert "invalid.yaml" in row[0]
+    assert "Syntax Error" in row[1].plain
+    assert "while parsing a flow sequence" in row[2].plain
+    assert "Analysed 1 files, found 1 invalid YAML files" in result.stdout
+    assert len(row[2].plain) == 32  # Cropped error message
+
+
+@patch("dagfactory.__main__.Table.add_row")
+def test_lint_invalid_yaml_verbose(mock_add_row, tmp_invalid_yaml_file):
+    result = runner.invoke(app, ["lint", str(tmp_invalid_yaml_file), "--verbose"])
+    assert result.exit_code == 1
+    row = mock_add_row.call_args[0]
+    assert "invalid.yaml" in row[0]
+    assert "Syntax Error" in row[1].plain
+    assert "while parsing a flow sequence" in row[2].plain
+    assert "Analysed 1 files, found 1 invalid YAML files" in result.stdout
+    assert len(row[2].plain) == 200  # Full error message

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -28,10 +28,6 @@ def test_version_option():
     assert result.exit_code == 0
     assert f"DAG Factory {__version__}" in result.output
 
-    result_short = runner.invoke(app, ["-v"])
-    assert result_short.exit_code == 0
-    assert f"DAG Factory {__version__}" in result_short.output
-
 
 def test_help_output_when_no_command():
     result = runner.invoke(app, [])


### PR DESCRIPTION
Introduce a lint command in the DAG Factory CLI.

There are two types of lint currently checked:
* Check if this is a valid YAML.
* Check if this is a DAG Factory compatible YAML (which has boolean operations and typing)

In future, this feature can be further improved by utilising a JSON Schema, as proposed in #87; however, it serves as a good starting point. The command can be used with or without the flag `--verbose`.

Related ticket: #445

**How this was tested**

Running

```bash
PYTHONPATH=`pwd` python -m dagfactory lint <path to directory or file>
```
Examples of invalid files:

```
# invalid-files/a.yml 
fruits:
  - [orange, mango
```

```
# invalid-files/b.yaml 
database
  host: localhost
```

**Screenshots**

Example running the lint command with success:
<img width="960" height="186" alt="Screenshot 2025-07-28 at 19 48 44" src="https://github.com/user-attachments/assets/c1086509-893e-47ab-bc51-d9c635fedfd9" />

Example running the lint command with invalid files:
<img width="812" height="190" alt="Screenshot 2025-07-28 at 19 48 04" src="https://github.com/user-attachments/assets/8b6c1f7d-c3fa-4ea3-84f5-edecbf62c26f" />

Example running the lint command using the `--verbose` flag:
<img width="874" height="304" alt="Screenshot 2025-07-28 at 19 47 54" src="https://github.com/user-attachments/assets/336e62ea-37cc-4893-9905-7d5116afb247" />
