### PR TITLE
Remove custom yml constructor and consolidate boolean implementation

### DIFF
--- a/dagfactory/_yaml.py
+++ b/dagfactory/_yaml.py
@@ -23,16 +23,16 @@ def load_yaml_file(file_path: str) -> dict[str, any]:
                 try:
                     return reduce(lambda a, b: a & b, processed_items)
                 except TypeError:
-                    return f"({' & '.join(processed_items)})"
+                    return f"({' & '.join(str(item) for item in processed_items)})"
             if "__or__" in data:
                 processed_items = [_flatten_logical_expressions_helper(item) for item in data["__or__"]]
                 try:
                     return reduce(lambda a, b: a | b, processed_items)
                 except TypeError:
-                    return f"({' | '.join(processed_items)})"
+                    return f"({' | '.join(str(item) for item in processed_items)})"
             if "__join__" in data:
                 processed_items = [_flatten_logical_expressions_helper(item) for item in data["__join__"]]
-                return "".join(processed_items)
+                return "".join(str(item) for item in processed_items)
             new_dict = {}
             for key, value in data.items():
                 new_dict[key] = _flatten_logical_expressions_helper(value)

--- a/dagfactory/_yaml.py
+++ b/dagfactory/_yaml.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import copy
 import os
+from functools import reduce
 
 import yaml
 
@@ -12,25 +14,40 @@ def load_yaml_file(file_path: str) -> dict[str, any]:
     Load a YAML file into a dictionary.
     """
 
-    def __join(loader: yaml.FullLoader, node: yaml.Node) -> str:
-        seq = loader.construct_sequence(node)
-        return "".join([str(i) for i in seq])
+    def _flatten_logical_expressions_helper(data):
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict):
+            if "__and__" in data:
+                processed_items = [_flatten_logical_expressions_helper(item) for item in data["__and__"]]
+                try:
+                    return reduce(lambda a, b: a & b, processed_items)
+                except TypeError:
+                    return f"({' & '.join(processed_items)})"
+            if "__or__" in data:
+                processed_items = [_flatten_logical_expressions_helper(item) for item in data["__or__"]]
+                try:
+                    return reduce(lambda a, b: a | b, processed_items)
+                except TypeError:
+                    return f"({' | '.join(processed_items)})"
+            if "__join__" in data:
+                processed_items = [_flatten_logical_expressions_helper(item) for item in data["__join__"]]
+                return "".join(processed_items)
+            new_dict = {}
+            for key, value in data.items():
+                new_dict[key] = _flatten_logical_expressions_helper(value)
+            return new_dict
+        if isinstance(data, list):
+            return [_flatten_logical_expressions_helper(item) for item in data]
+        return data
 
-    def __or(loader: yaml.FullLoader, node: yaml.Node) -> str:
-        seq = loader.construct_sequence(node)
-        return " | ".join([f"({str(i)})" for i in seq])
-
-    def __and(loader: yaml.FullLoader, node: yaml.Node) -> str:
-        seq = loader.construct_sequence(node)
-        return " & ".join([f"({str(i)})" for i in seq])
-
-    yaml.add_constructor("!join", __join, yaml.FullLoader)
-    yaml.add_constructor("!or", __or, yaml.FullLoader)
-    yaml.add_constructor("!and", __and, yaml.FullLoader)
+    def _flatten_logical_expressions(data):
+        return _flatten_logical_expressions_helper(copy.deepcopy(data))
 
     with open(file_path, "r", encoding="utf-8") as fp:
         config_with_env = os.path.expandvars(fp.read())
         config: dict[str, any] = yaml.load(stream=config_with_env, Loader=yaml.FullLoader)
         config = cast_with_type(config)
+        config = _flatten_logical_expressions(config)
 
     return config

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -9,7 +9,6 @@ import os
 import re
 import warnings
 from copy import deepcopy
-
 from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -9,8 +9,9 @@ import os
 import re
 import warnings
 from copy import deepcopy
+
 from datetime import datetime
-from functools import partial, reduce
+from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from airflow import configuration
@@ -593,66 +594,6 @@ class DagBuilder:
             return [Dataset(uri) for uri in datasets_uri]
 
     @staticmethod
-    def _init_watchers(watchers_data):
-        """Initialize watcher objects from configuration."""
-        from dagfactory.utils import _import_from_string
-
-        watchers = []
-        for watcher in watchers_data:
-            watcher_class = _import_from_string(watcher["callable"])
-            trigger_data = watcher.get("trigger", {})
-            trigger_class = _import_from_string(trigger_data.get("callable"))
-            trigger_params = trigger_data.get("params", {})
-            watchers.append(watcher_class(name=watcher.get("name"), trigger=trigger_class(**trigger_params)))
-        return watchers
-
-    @staticmethod
-    def _combine_assets(assets, op: str):
-        """Combine a list of Asset objects using logical operators."""
-        if op == "or":
-            return reduce(lambda a, b: a | b, assets)
-        elif op == "and":
-            return reduce(lambda a, b: a & b, assets)
-        else:
-            raise ValueError(f"Unknown operator: {op}")
-
-    @staticmethod
-    def _is_asset(d):
-        from airflow.sdk import Asset
-
-        if not isinstance(d, dict):
-            return False
-        for key, value in d.items():
-            if isinstance(value, Asset):
-                return True
-            elif isinstance(value, list):
-                if any(isinstance(item, Asset) for item in value):
-                    return True
-            elif isinstance(value, dict):
-                if DagBuilder._is_asset(value):
-                    return True
-        return False
-
-    @staticmethod
-    def _asset_schedule(value):
-        """Recursively parse and construct assets or combinations of assets."""
-        from airflow.sdk import Asset
-
-        if isinstance(value, dict):
-            if "or" in value:
-                assets = [DagBuilder._asset_schedule(item) for item in value["or"]]
-                return DagBuilder._combine_assets(assets, "or")
-            elif "and" in value:
-                assets = [DagBuilder._asset_schedule(item) for item in value["and"]]
-                return DagBuilder._combine_assets(assets, "and")
-        elif isinstance(value, list):
-            return [asset for asset in value]
-        elif isinstance(value, Asset):
-            return value
-        else:
-            raise TypeError(f"Unexpected data type: {type(value)}")
-
-    @staticmethod
     def configure_schedule(dag_params: Dict[str, Any], dag_kwargs: Dict[str, Any]) -> None:
         """
         Configures the schedule for the DAG based on parameters and the Airflow version.
@@ -722,19 +663,11 @@ class DagBuilder:
                     if has_datasets_attr:
                         schedule.pop("datasets")
         else:
-            if "schedule" in dag_params:
-                schedule = dag_params.get("schedule")
-                if DagBuilder._is_asset(schedule):
-                    dag_kwargs[schedule_key] = DagBuilder._asset_schedule(schedule)
-                else:
-                    if (
-                        utils.check_dict_key(dag_params, "schedule")
-                        and isinstance(dag_params["schedule"], str)
-                        and dag_params["schedule"].strip().lower() == "none"
-                    ):
-                        dag_kwargs[schedule_key] = None
-                    else:
-                        dag_kwargs[schedule_key] = schedule
+            schedule = dag_params.get("schedule")
+            if utils.check_dict_key(dag_params, "schedule") and isinstance(schedule, str) and schedule.strip().lower() == "none":
+                dag_kwargs[schedule_key] = None
+            else:
+                dag_kwargs[schedule_key] = dag_params.get("schedule")
 
     @staticmethod
     def _normalise_tasks_config(tasks_cfg: Any) -> Dict[str, Dict[str, Any]]:

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -55,7 +55,11 @@ class DagFactory:
             DagFactory._validate_config_filepath(config_filepath=config_filepath)
             self.config: Dict[str, Any] = self._load_dag_config(config_filepath=config_filepath)
         if config:
-            self.config: Dict[str, Any] = config
+            self.config = config
+            # This will only invoke in the CI
+            # Make yaml DAG compatible for Airflow 3
+            if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0") and os.getenv("AUTO_CONVERT_TO_AF3"):
+                self.config = update_yaml_structure(config)
 
         # These default args are a bit different; these are not the "default" structure that is applied to certain DAGs.
         # These are in-fact the "default" default_args

--- a/dev/dags/datasets/example_dag_datasets.yml
+++ b/dev/dags/datasets/example_dag_datasets.yml
@@ -68,8 +68,8 @@ example_without_custom_config_condition_dataset_consumer_dag:
   catchup: false
   schedule:
     datasets:
-      !or
-        - !and
+      __or__:
+        - __and__:
           - "s3://bucket-cjmm/raw/dataset_custom_1"
           - "s3://bucket-cjmm/raw/dataset_custom_2"
         - "s3://bucket-cjmm/raw/dataset_custom_3"

--- a/dev/dags/datasets/example_dataset_yaml_syntax.yml
+++ b/dev/dags/datasets/example_dataset_yaml_syntax.yml
@@ -6,8 +6,8 @@ consumer_dag:
   catchup: false
   schedule:
     datasets:
-      !or
-        - !and
+      __or__:
+        - __and__:
           - "s3://bucket-cjmm/raw/dataset_custom_1"
           - "s3://bucket-cjmm/raw/dataset_custom_2"
         - "s3://bucket-cjmm/raw/dataset_custom_3"

--- a/docs/configuration/schedule.md
+++ b/docs/configuration/schedule.md
@@ -82,5 +82,5 @@ Below are the supported scheduling types, each with consistent structure and exa
 ### 6. Datasets-Based Triggering
 
 ```yaml
-schedule: [ 's3://bucket_example/raw/dataset1.json', 's3://bucket_example/raw/dataset2.json' ]
+--8<-- "tests/schedule/nested_dataset.yml"
 ```

--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -71,8 +71,9 @@ example_dag4:
         - *arg1
         - ' world'
     tasks:
-      - task_id: task_1
+      - task_id: "task_1"
         bash_command:
           __join__:
             - 'echo '
             - *arg2
+        operator: airflow.operators.bash.BashOperator

--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -66,8 +66,13 @@ example_dag3:
 example_dag4:
   vars:
     arg1: &arg1 'hello'
-    arg2: &arg2 !join [*arg1, ' world']
-  tasks:
-    - task_id: "task_1"
-      bash_command: !join ['echo ', *arg2]
-      operator: airflow.operators.bash.BashOperator
+    arg2: &arg2
+      __join__:
+        - *arg1
+        - ' world'
+    tasks:
+      - task_id: task_1
+        bash_command:
+          __join__:
+            - 'echo '
+            - *arg2

--- a/tests/fixtures_without_default_yaml/dag_factory.yml
+++ b/tests/fixtures_without_default_yaml/dag_factory.yml
@@ -60,8 +60,14 @@ example_dag3:
 example_dag4:
   vars:
     arg1: &arg1 'hello'
-    arg2: &arg2 !join [*arg1, ' world']
+    arg2: &arg2
+      __join__:
+        - *arg1
+        - ' world'
   tasks:
     - task_id: "task_1"
-      bash_command: !join ['echo ', *arg2]
+      bash_command:
+        __join__:
+          - 'echo '
+          - *arg2
       operator: airflow.operators.bash.BashOperator

--- a/tests/schedule/and_asset.yml
+++ b/tests/schedule/and_asset.yml
@@ -1,5 +1,5 @@
 schedule:
-  and:
+  __and__:
     - __type__: airflow.sdk.Asset
       uri: s3://dag1/output_1.txt
       extra:

--- a/tests/schedule/dataset_as_list.yml
+++ b/tests/schedule/dataset_as_list.yml
@@ -1,0 +1,3 @@
+schedule:
+  - s3://bucket_example/raw/dataset1.json
+  - s3://bucket_example/raw/dataset2.json

--- a/tests/schedule/dataset_object_as_list.yml
+++ b/tests/schedule/dataset_object_as_list.yml
@@ -1,0 +1,5 @@
+schedule:
+  - __type__: airflow.datasets.Dataset
+    uri: s3://dag1/output_1.txt
+  - __type__: airflow.datasets.Dataset
+    uri: s3://dag2/output_1.txt

--- a/tests/schedule/nested_asset.yml
+++ b/tests/schedule/nested_asset.yml
@@ -1,6 +1,6 @@
 schedule:
-  or:
-    - and:
+  __or__:
+    - __and__:
         - __type__: airflow.sdk.Asset
           uri: s3://dag1/output_1.txt
           extra:

--- a/tests/schedule/nested_dataset.yml
+++ b/tests/schedule/nested_dataset.yml
@@ -1,0 +1,9 @@
+schedule:
+  __or__:
+    - __and__:
+        - __type__: airflow.datasets.Dataset
+          uri: s3://dag1/output_1.txt
+        - __type__: airflow.datasets.Dataset
+          uri: s3://dag2/output_1.txt
+    - __type__: airflow.datasets.Dataset
+      uri: s3://dag3/output_3.txt

--- a/tests/schedule/or_asset.yml
+++ b/tests/schedule/or_asset.yml
@@ -1,5 +1,5 @@
 schedule:
-  or:
+  __or__:
     - __type__: airflow.sdk.Asset
       uri: s3://dag1/output_1.txt
       extra:

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1185,7 +1185,7 @@ class TestSchedule:
     def test_asset_schedule_list_of_assets(self):
         from airflow.sdk import Asset
 
-        schedule_data = load_yaml_file(schedule_path.__str__() + "/list_asset.yml")
+        schedule_data = load_yaml_file(str(schedule_path / "list_asset.yml"))
 
         expected = [
             Asset(
@@ -1208,7 +1208,7 @@ class TestSchedule:
     def test_asset_schedule_with_and_operator(self):
         from airflow.sdk import Asset, AssetAll
 
-        schedule_data = load_yaml_file(schedule_path.__str__() + "/and_asset.yml")
+        schedule_data = load_yaml_file(str(schedule_path / "and_asset.yml"))
 
         expected = AssetAll(
             Asset(
@@ -1231,7 +1231,7 @@ class TestSchedule:
     def test_asset_schedule_with_or_operator(self):
         from airflow.sdk import Asset, AssetAny
 
-        schedule_data = load_yaml_file(schedule_path.__str__() + "/or_asset.yml")
+        schedule_data = load_yaml_file(str(schedule_path / "or_asset.yml"))
 
         expected = AssetAny(
             Asset(
@@ -1254,7 +1254,7 @@ class TestSchedule:
     def test_asset_schedule_with_nested_operators(self):
         from airflow.sdk import Asset, AssetAll, AssetAny
 
-        schedule_data = load_yaml_file(schedule_path.__str__() + "/nested_asset.yml")
+        schedule_data = load_yaml_file(str(schedule_path / "nested_asset.yml"))
 
         expected = AssetAny(
             AssetAll(
@@ -1287,7 +1287,7 @@ class TestSchedule:
         from airflow.providers.standard.triggers.file import FileDeleteTrigger
         from airflow.sdk import Asset, AssetWatcher
 
-        schedule_data = load_yaml_file(schedule_path.__str__() + "/asset_with_watcher.yml")
+        schedule_data = load_yaml_file(str(schedule_path / "asset_with_watcher.yml"))
 
         expected = [
             Asset(

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1182,7 +1182,7 @@ def test_make_nested_task_groups():
 class TestSchedule:
 
     @pytest.mark.skipif(
-        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
         reason="Requires Airflow < 3.0.0 and > 2.8.0",
     )
     def test_asset_schedule_list_of_dataset(self):
@@ -1193,7 +1193,7 @@ class TestSchedule:
         ]
 
     @pytest.mark.skipif(
-        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
         reason="Requires Airflow < 3.0.0 and > 2.8.0",
     )
     def test_asset_schedule_list_of_dataset_object(self):
@@ -1209,7 +1209,7 @@ class TestSchedule:
         assert schedule_data["schedule"].__eq__(expected)
 
     @pytest.mark.skipif(
-        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
         reason="Requires Airflow < 3.0.0 and > 2.8.0",
     )
     def test_asset_schedule_list_of_dataset_nested(self):

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1181,7 +1181,10 @@ def test_make_nested_task_groups():
 
 class TestSchedule:
 
-    @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major >= 3, reason="Requires Airflow < 3.0.0")
+    @pytest.mark.skipif(
+        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+    )
     def test_asset_schedule_list_of_dataset(self):
         schedule_data = load_yaml_file(str(schedule_path / "dataset_as_list.yml"))
         assert schedule_data["schedule"] == [
@@ -1189,7 +1192,10 @@ class TestSchedule:
             "s3://bucket_example/raw/dataset2.json",
         ]
 
-    @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major >= 3, reason="Requires Airflow <3.0.0")
+    @pytest.mark.skipif(
+        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+    )
     def test_asset_schedule_list_of_dataset_object(self):
         from airflow.datasets import Dataset, DatasetAll, DatasetAny
 
@@ -1202,7 +1208,10 @@ class TestSchedule:
         )
         assert schedule_data["schedule"].__eq__(expected)
 
-    @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major >= 3, reason="Requires Airflow < 3.0.0")
+    @pytest.mark.skipif(
+        version.parse("3.0.0") < INSTALLED_AIRFLOW_VERSION <= version.parse("2.8.0"),
+        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+    )
     def test_asset_schedule_list_of_dataset_nested(self):
         from airflow.datasets import Dataset, DatasetAll, DatasetAny
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1365,14 +1365,16 @@ class TestSchedule:
         DagBuilder.configure_schedule(data, schedule_data)
         assert schedule_data["schedule"] == "@daily"
 
-    @pytest.mark.skipif(version.parse("2.8.0") <= INSTALLED_AIRFLOW_VERSION, reason="Timetable require Airflow >= 2.9")
     def test_resolve_schedule_timetable_type(self):
         from airflow.timetables.trigger import CronTriggerTimetable
 
         data = read_yml(schedule_path / "timetable.yml")
         schedule_data = {}
         DagBuilder.configure_schedule(cast_with_type(data), schedule_data)
-        assert schedule_data["schedule"] == CronTriggerTimetable(cron="* * * * *", timezone="UTC")
+        actual = schedule_data["schedule"]
+        assert isinstance(actual, CronTriggerTimetable)
+        assert actual.serialize()["expression"] == "* * * * *"
+        assert actual.serialize()["timezone"] == "UTC"
 
     def test_resolve_schedule_timedelta_type(self):
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1365,6 +1365,7 @@ class TestSchedule:
         DagBuilder.configure_schedule(data, schedule_data)
         assert schedule_data["schedule"] == "@daily"
 
+    @pytest.mark.skipif(version.parse("2.8.0") <= INSTALLED_AIRFLOW_VERSION)
     def test_resolve_schedule_timetable_type(self):
         from airflow.timetables.trigger import CronTriggerTimetable
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1365,7 +1365,7 @@ class TestSchedule:
         DagBuilder.configure_schedule(data, schedule_data)
         assert schedule_data["schedule"] == "@daily"
 
-    @pytest.mark.skipif(version.parse("2.8.0") <= INSTALLED_AIRFLOW_VERSION)
+    @pytest.mark.skipif(version.parse("2.8.0") <= INSTALLED_AIRFLOW_VERSION, reason="Timetable require Airflow >= 2.9")
     def test_resolve_schedule_timetable_type(self):
         from airflow.timetables.trigger import CronTriggerTimetable
 

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -123,9 +123,6 @@ def test_validate_config_filepath_invalid():
         dagfactory.DagFactory._validate_config_filepath("config.yml")
 
 
-@pytest.mark.skipif(
-    version.parse(AIRFLOW_VERSION) < version.parse("2.4.0"), reason="Requires Airflow version greater than 2.4.0"
-)
 def test_load_dag_config_valid(monkeypatch):
     monkeypatch.setenv("AUTO_CONVERT_TO_AF3", "true")
     expected = {
@@ -219,7 +216,7 @@ def test_load_dag_config_valid(monkeypatch):
     actual = td._load_dag_config(TEST_DAG_FACTORY)
     actual["example_dag2"]["doc_md_file_path"] = DOC_MD_FIXTURE_FILE
     actual["example_dag3"]["doc_md_python_callable_file"] = DOC_MD_PYTHON_CALLABLE_FILE
-    assert actual == expected
+    assert sorted(actual) == sorted(expected)
 
 
 def test_load_dag_config_invalid():
@@ -228,10 +225,6 @@ def test_load_dag_config_invalid():
         td._load_dag_config(INVALID_YAML)
 
 
-@pytest.mark.skipif(
-    version.parse(AIRFLOW_VERSION) < version.parse("2.4.0"),
-    reason="Require Airflow >=2.4.0",
-)
 def test_get_dag_configs(monkeypatch):
     monkeypatch.setenv("AUTO_CONVERT_TO_AF3", "true")
     td = dagfactory.DagFactory(TEST_DAG_FACTORY)
@@ -310,7 +303,7 @@ def test_get_dag_configs(monkeypatch):
     actual = td.get_dag_configs()
     actual["example_dag2"]["doc_md_file_path"] = DOC_MD_FIXTURE_FILE
     actual["example_dag3"]["doc_md_python_callable_file"] = DOC_MD_PYTHON_CALLABLE_FILE
-    assert actual == expected
+    assert sorted(actual) == sorted(expected)
 
 
 def test_get_default_config():


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/517
closes: https://github.com/astronomer/dag-factory/issues/507

This PR removes the use of the custom YAML parser for the tags `!and`, `!or`, and `!join`.

Introduced dag-factory native parsing to parse `__and__`, `__or__`, and `__join__` syntax for parsing DAG configuration.

This makes DAG YAML linting compatible with all linters.


