### PR TITLE
Remove `AUTO_CONVERT_TO_AF3` from tests

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -117,8 +117,6 @@ jobs:
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-cov
-        env:
-          AUTO_CONVERT_TO_AF3: true
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -197,7 +195,6 @@ jobs:
           AIRFLOW_HOME: ${{ github.workspace }}
           CONFIG_ROOT_DIR: ${{ github.workspace }}/dags
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/dev/dags:$PYTHONPATH
-          AUTO_CONVERT_TO_AF3: true
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,7 +2,6 @@
 FROM astrocrpublic.azurecr.io/runtime:3.0-4
 
 ENV CONFIG_ROOT_DIR=/usr/local/airflow/dags/
-ENV AUTO_CONVERT_TO_AF3=True
 ENV PYTHONPATH=$AIRFLOW_HOME/dags:$PYTHONPATH
 
 USER root

--- a/docs/contributing/howto.md
+++ b/docs/contributing/howto.md
@@ -146,12 +146,6 @@ The [pyproject. toml](https://github.com/astronomer/dag-factory/blob/main/pyproj
 !!! note
     - These tests create local Python virtual environments in a hatch-managed directory.
 
-If you have YAMLs written for Airflow 2 and would like them to be run for Airflow 3 tests, set the following environment variable for DAG Factory to convert and make them compatible with Airflow 3:
-
-```bash
-export AUTO_CONVERT_TO_AF3=true
-```
-
 To run unit tests using Python 3.10 and Airflow 2.5, use the following:
 
 ```bash
@@ -169,7 +163,6 @@ hatch run tests:test-cov
 !!! note
     - These tests create local Python virtual environments within a `hatch`-managed directory.
     - They also use the user-defined `AIRFLOW_HOME`, overriding any pre-existing `airflow.cfg` and `airflow.db` files.
-    - The `AUTO_CONVERT_TO_AF3` environment variable is required to run tests in the Airflow 3 environment.
 
 First, set the following environment variables:
 
@@ -178,7 +171,6 @@ export AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT=90
 export AIRFLOW_HOME=$(pwd)/dev/
 export CONFIG_ROOT_DIR=$(pwd)/dev/dags
 export PYTHONPATH=$(pwd)/dev/dags:$PYTHONPATH
-export AUTO_CONVERT_TO_AF3=true
 ```
 
 To run the integration tests using Python 3.9 and Airflow 2.9, use

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -124,7 +124,6 @@ def test_validate_config_filepath_invalid():
 
 
 def test_load_dag_config_valid(monkeypatch):
-    monkeypatch.setenv("AUTO_CONVERT_TO_AF3", "true")
     expected = {
         "default": {
             "default_args": {
@@ -226,7 +225,6 @@ def test_load_dag_config_invalid():
 
 
 def test_get_dag_configs(monkeypatch):
-    monkeypatch.setenv("AUTO_CONVERT_TO_AF3", "true")
     td = dagfactory.DagFactory(TEST_DAG_FACTORY)
     expected = {
         "example_dag": {
@@ -367,7 +365,6 @@ def test_kubernetes_pod_operator_dag_lt_2_7():
 
 
 def test_variables_as_arguments_dag(monkeypatch):
-    monkeypatch.setenv("AUTO_CONVERT_TO_AF3", "true")
     override_command = "value_from_variable"
     os.environ["AIRFLOW_VAR_VAR1"] = override_command
     td = dagfactory.DagFactory(DAG_FACTORY_VARIABLES_AS_ARGUMENTS)


### PR DESCRIPTION
Remove automatic conversion of Airflow 2 to 3 DAGs in our tests / CI.

This work was started in #539 to allow the tests to pass.