### PR TITLE
Capture Telemetry DNS gaierror and handle it gracefully

### DIFF
--- a/dagfactory/telemetry.py
+++ b/dagfactory/telemetry.py
@@ -48,7 +48,7 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
     logging.debug("Telemetry is enabled. Emitting the following usage metrics to %s: %s", telemetry_url, metrics)
     try:
         response = httpx.get(telemetry_url, timeout=constants.TELEMETRY_TIMEOUT, follow_redirects=True)
-    except (httpx.HTTPError, socket.gaierror) as e:
+    except Exception as e:  # We are exceptionally capturing Exception since telemetry should not fail DAG parsing in any scenario
         logging.warning("Unable to emit usage metrics to %s. An error occurred: %s.", telemetry_url, str(e))
         is_success = False
     else:

--- a/dagfactory/telemetry.py
+++ b/dagfactory/telemetry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import platform
-import socket
 from urllib import parse
 from urllib.parse import urlencode
 
@@ -48,7 +47,9 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
     logging.debug("Telemetry is enabled. Emitting the following usage metrics to %s: %s", telemetry_url, metrics)
     try:
         response = httpx.get(telemetry_url, timeout=constants.TELEMETRY_TIMEOUT, follow_redirects=True)
-    except Exception as e:  # We are exceptionally capturing Exception since telemetry should not fail DAG parsing in any scenario
+    except (
+        Exception
+    ) as e:  # We are exceptionally capturing Exception since telemetry should not fail DAG parsing in any scenario
         logging.warning("Unable to emit usage metrics to %s. An error occurred: %s.", telemetry_url, str(e))
         is_success = False
     else:

--- a/dagfactory/telemetry.py
+++ b/dagfactory/telemetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import socket
 from urllib import parse
 from urllib.parse import urlencode
 
@@ -47,10 +48,8 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
     logging.debug("Telemetry is enabled. Emitting the following usage metrics to %s: %s", telemetry_url, metrics)
     try:
         response = httpx.get(telemetry_url, timeout=constants.TELEMETRY_TIMEOUT, follow_redirects=True)
-    except httpx.HTTPError as e:
-        logging.warning(
-            "Unable to emit usage metrics to %s. An HTTPX connection error occurred: %s.", telemetry_url, str(e)
-        )
+    except (httpx.HTTPError, socket.gaierror) as e:
+        logging.warning("Unable to emit usage metrics to %s. An error occurred: %s.", telemetry_url, str(e))
         is_success = False
     else:
         is_success = response.is_success


### PR DESCRIPTION
Once we introduced Telemetry in DAG Factory 0.20, if the telemetry endpoint was not reachable, DAG Factory would fail to parse the DAG, raising:
```
Broken DAG: [/usr/local/airflow/dags/dag_factory.py]
Traceback (most recent call last):
File "/usr/local/lib/python3.11/socket.py", line 827, in create_connection
for res in getaddrinfo(host, port, 0, SOCK_STREAM):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/socket.py", line 962, in getaddrinfo
for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -3] Temporary failure in name resolution
```

Closes: #275
