### PR TITLE
Rename parameter in `load_yaml_dags` to reflect behaviour

### DIFF
--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -30,46 +30,46 @@ class _DagFactory:
     :param config_filepath: the filepath of the DAG factory YAML config file.
         Must be absolute path to file. Cannot be used with `config`.
     :type config_filepath: str
-    :param config: DAG factory config dictionary. Cannot be used with `config_filepath`.
-    :type config: dict
-    :param default_args_config_path: The path to a file that contains the default arguments for that DAG.
-    :type default_args_config_path: str
-    :param default_args_config_dict: A dictionary of default arguments for that DAG, as an alternative to default_args_config_path.
-    :type default_args_config_dict: dict
+    :param config_dict: DAG factory config dictionary. Cannot be used with `config_filepath`.
+    :type config_dict: dict
+    :param defaults_config_path: The path to a file that contains the default arguments for that DAG.
+    :type defaults_config_path: str
+    :param default_config_dict: A dictionary of default arguments for that DAG, as an alternative to default_args_config_path.
+    :type default_config_dict: dict
     """
 
     def __init__(
         self,
         config_filepath: Optional[str] = None,
-        config: Optional[dict] = None,
-        default_args_config_path: str = airflow_conf.get("core", "dags_folder"),
-        default_args_config_dict: Optional[dict] = None,
+        config_dict: Optional[dict] = None,
+        defaults_config_path: str = airflow_conf.get("core", "dags_folder"),
+        default_config_dict: Optional[dict] = None,
     ) -> None:
         # Handle the config(_filepath)
-        assert bool(config_filepath) ^ bool(config), "Either `config_filepath` or `config` should be provided"
+        assert bool(config_filepath) ^ bool(config_dict), "Either `config_filepath` or `config` should be provided"
 
         if config_filepath:
             _DagFactory._validate_config_filepath(config_filepath=config_filepath)
             self.config: Dict[str, Any] = self._load_dag_config(config_filepath=config_filepath)
-        if config:
-            self.config = config
+        if config_dict:
+            self.config = config_dict
 
         # These default args are a bit different; these are not the "default" structure that is applied to certain DAGs.
         # These are in-fact the "default" default_args
-        if default_args_config_dict:
+        if default_config_dict:
             # Log a warning if the default_args parameter is specified. If both the default_args and
             # default_args_file_path are passed, we'll throw an exception.
             logging.warning(
                 "Manually specifying `default_args_config_dict` will override the values in the `defaults.yml` file."
             )
 
-            if default_args_config_path != airflow_conf.get("core", "dags_folder"):
+            if defaults_config_path != airflow_conf.get("core", "dags_folder"):
                 raise DagFactoryException("Cannot pass both `default_args_config_dict` and `default_args_config_path`.")
 
         # We'll still go ahead and set both values. They'll be referenced in _global_default_args.
         self.config_file_path: str = config_filepath
-        self.default_args_config_path: str = default_args_config_path
-        self.default_args_config_dict: Optional[dict] = default_args_config_dict
+        self.default_args_config_path: str = defaults_config_path
+        self.default_args_config_dict: Optional[dict] = default_config_dict
 
     def _global_default_args(self):
         """
@@ -274,10 +274,10 @@ class _DagFactory:
 def load_yaml_dags(
     globals_dict: Dict[str, Any],
     dags_folder: str = airflow_conf.get("core", "dags_folder"),
-    default_args_config_path: str = airflow_conf.get("core", "dags_folder"),
     config_filepath: Optional[str] = None,
+    defaults_config_path: str = airflow_conf.get("core", "dags_folder"),
     config_dict: Optional[dict] = None,
-    default_args_config_dict: Optional[dict] = None,
+    default_config_dict: Optional[dict] = None,
     suffix=None,
 ):
     """
@@ -289,10 +289,10 @@ def load_yaml_dags(
 
     :param globals_dict: The globals() from the file used to generate DAGs
     :param dags_folder: Path to the folder you want to get recursively scanned
-    :param default_args_config_path: The Folder path where defaults.yml exist.
     :param config_filepath: A YAML path for DAG config.
+    :param defaults_config_path: The Folder path where defaults.yml exist.
     :param config_dict: The DAG dictionary.
-    :param default_args_config_dict: The dictionary that hold default value.
+    :param default_config_dict: The dictionary that hold default value.
     :param suffix: file suffix to filter `in` what files to scan for dags
     """
     # TODO: Support ignoring yml files in load_yaml_dags
@@ -304,10 +304,10 @@ def load_yaml_dags(
     candidate_dag_files = []
 
     if config_filepath:
-        factory = _DagFactory(config_filepath=config_filepath, default_args_config_path=default_args_config_path)
+        factory = _DagFactory(config_filepath=config_filepath, defaults_config_path=defaults_config_path)
         factory._generate_dags(globals_dict)
     elif config_dict:
-        factory = _DagFactory(config=config_dict, default_args_config_dict=default_args_config_dict)
+        factory = _DagFactory(config_dict=config_dict, default_config_dict=default_config_dict)
         factory._generate_dags(globals_dict)
     else:
         for suf in suffix:
@@ -316,7 +316,7 @@ def load_yaml_dags(
             config_file_abs_path = str(config_file_path.absolute())
             logging.info("Loading %s", config_file_abs_path)
             try:
-                factory = _DagFactory(config_file_abs_path, default_args_config_path=default_args_config_path)
+                factory = _DagFactory(config_file_abs_path, default_config_dict=default_config_dict)
                 factory._generate_dags(globals_dict)
             except Exception:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -34,8 +34,8 @@ class _DagFactory:
     :type config_dict: dict
     :param defaults_config_path: The path to a file that contains the default arguments for that DAG.
     :type defaults_config_path: str
-    :param default_config_dict: A dictionary of default arguments for that DAG, as an alternative to default_args_config_path.
-    :type default_config_dict: dict
+    :param defaults_config_dict: A dictionary of default arguments for that DAG, as an alternative to default_args_config_path.
+    :type defaults_config_dict: dict
     """
 
     def __init__(
@@ -43,7 +43,7 @@ class _DagFactory:
         config_filepath: Optional[str] = None,
         config_dict: Optional[dict] = None,
         defaults_config_path: str = airflow_conf.get("core", "dags_folder"),
-        default_config_dict: Optional[dict] = None,
+        defaults_config_dict: Optional[dict] = None,
     ) -> None:
         # Handle the config(_filepath)
         assert bool(config_filepath) ^ bool(config_dict), "Either `config_filepath` or `config` should be provided"
@@ -56,7 +56,7 @@ class _DagFactory:
 
         # These default args are a bit different; these are not the "default" structure that is applied to certain DAGs.
         # These are in-fact the "default" default_args
-        if default_config_dict:
+        if defaults_config_dict:
             # Log a warning if the default_args parameter is specified. If both the default_args and
             # default_args_file_path are passed, we'll throw an exception.
             logging.warning(
@@ -69,15 +69,15 @@ class _DagFactory:
         # We'll still go ahead and set both values. They'll be referenced in _global_default_args.
         self.config_file_path: str = config_filepath
         self.default_args_config_path: str = defaults_config_path
-        self.default_args_config_dict: Optional[dict] = default_config_dict
+        self.defaults_config_dict: Optional[dict] = defaults_config_dict
 
     def _global_default_args(self):
         """
         If self.default_args exists, use this as the global default_args (to be applied to each DAG). Otherwise, fall
         back to the defaults.yml file.
         """
-        if self.default_args_config_dict:
-            return self.default_args_config_dict
+        if self.defaults_config_dict:
+            return self.defaults_config_dict
 
         configs_list = self._retrieve_default_config_list()
         merged_default_config = {
@@ -277,7 +277,7 @@ def load_yaml_dags(
     config_filepath: Optional[str] = None,
     defaults_config_path: str = airflow_conf.get("core", "dags_folder"),
     config_dict: Optional[dict] = None,
-    default_config_dict: Optional[dict] = None,
+    defaults_config_dict: Optional[dict] = None,
     suffix=None,
 ):
     """
@@ -292,7 +292,7 @@ def load_yaml_dags(
     :param config_filepath: A YAML path for DAG config.
     :param defaults_config_path: The Folder path where defaults.yml exist.
     :param config_dict: The DAG dictionary.
-    :param default_config_dict: The dictionary that hold default value.
+    :param defaults_config_dict: The dictionary that hold default value.
     :param suffix: file suffix to filter `in` what files to scan for dags
     """
     # TODO: Support ignoring yml files in load_yaml_dags
@@ -307,7 +307,7 @@ def load_yaml_dags(
         factory = _DagFactory(config_filepath=config_filepath, defaults_config_path=defaults_config_path)
         factory._generate_dags(globals_dict)
     elif config_dict:
-        factory = _DagFactory(config_dict=config_dict, default_config_dict=default_config_dict)
+        factory = _DagFactory(config_dict=config_dict, defaults_config_dict=defaults_config_dict)
         factory._generate_dags(globals_dict)
     else:
         for suf in suffix:
@@ -316,7 +316,7 @@ def load_yaml_dags(
             config_file_abs_path = str(config_file_path.absolute())
             logging.info("Loading %s", config_file_abs_path)
             try:
-                factory = _DagFactory(config_file_abs_path, default_config_dict=default_config_dict)
+                factory = _DagFactory(config_file_abs_path, defaults_config_dict=defaults_config_dict)
                 factory._generate_dags(globals_dict)
             except Exception:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)

--- a/dev/dags/example_dag_factory_default_config_dict.py
+++ b/dev/dags/example_dag_factory_default_config_dict.py
@@ -26,5 +26,5 @@ daily_etl = {
 load_yaml_dags(
     globals_dict=globals(),
     config_dict=daily_etl,
-    default_args_config_dict={"default_args": {"start_date": "2025-01-01", "owner": "global_owner"}},
+    defaults_config_dict={"default_args": {"start_date": "2025-01-01", "owner": "global_owner"}},
 )

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -478,7 +478,7 @@ def test_none_string_schedule_supplied():
 
 
 def test_dagfactory_dict():
-    td = _DagFactory(config=DAG_FACTORY_CONFIG)
+    td = _DagFactory(config_dict=DAG_FACTORY_CONFIG)
     expected_default = {
         "default_args": {
             "owner": "airflow",
@@ -508,7 +508,7 @@ def test_dagfactory_dict():
 def test_dagfactory_dict_and_yaml():
     error_message = "Either `config_filepath` or `config` should be provided"
     with pytest.raises(AssertionError, match=error_message):
-        _DagFactory(config_filepath=TEST_DAG_FACTORY, config=DAG_FACTORY_CONFIG)
+        _DagFactory(config_filepath=TEST_DAG_FACTORY, config_dict=DAG_FACTORY_CONFIG)
 
 
 def test_get_dag_configs_dict():
@@ -528,7 +528,7 @@ def test_generate_dags_with_removal_valid_and_callback():
 
 
 def test_set_callback_after_loading_config():
-    td = _DagFactory(config=DAG_FACTORY_CONFIG)  # Generate the DAG factory object
+    td = _DagFactory(config_dict=DAG_FACTORY_CONFIG)  # Generate the DAG factory object
     td.config["default"]["default_args"]["on_success_callback"] = f"{__name__}.print_context_callback"
     load_yaml_dags(
         globals_dict=globals(),
@@ -537,7 +537,7 @@ def test_set_callback_after_loading_config():
 
 
 def test_build_dag_with_global_default():
-    dags = _DagFactory(config=DAG_FACTORY_CONFIG, default_args_config_path=DEFAULT_ARGS_CONFIG_ROOT).build_dags()
+    dags = _DagFactory(config_dict=DAG_FACTORY_CONFIG, defaults_config_path=DEFAULT_ARGS_CONFIG_ROOT).build_dags()
 
     assert dags.get("example_dag").tasks[0].depends_on_past == True
 
@@ -562,7 +562,7 @@ def test_build_dag_with_global_dag_level_defaults():
         },
     }
 
-    td = _DagFactory(config=config)
+    td = _DagFactory(config_dict=config)
     with pytest.MonkeyPatch.context() as m:
         m.setattr(td, "_global_default_args", lambda: global_defaults)
         dags = td.build_dags()
@@ -577,8 +577,8 @@ def test_build_dag_with_global_dag_level_defaults():
 
 def test_build_dag_with_global_default_dict():
     dags = _DagFactory(
-        config=DAG_FACTORY_CONFIG,
-        default_args_config_dict={
+        config_dict=DAG_FACTORY_CONFIG,
+        defaults_config_dict={
             "default_args": {"start_date": "2025-01-01", "owner": "global_owner", "depends_on_past": True}
         },
     ).build_dags()
@@ -693,7 +693,7 @@ def test_retrieve_possible_default_config_dirs_default_path_is_parent(tmp_path):
 
     default_config_path = tmp_path / "a"
 
-    some_dag = _DagFactory(str(dag_file), default_args_config_path=str(default_config_path))
+    some_dag = _DagFactory(str(dag_file), defaults_config_path=str(default_config_path))
 
     result = some_dag._retrieve_possible_default_config_dirs()
     expected = [tmp_path / "a" / "b" / "c", tmp_path / "a" / "b", tmp_path / "a"]
@@ -710,7 +710,7 @@ def test_retrieve_possible_default_config_dirs_default_path_not_in_config_parent
     unrelated_default_path = tmp_path / "other"
     unrelated_default_path.mkdir()
 
-    some_dag = _DagFactory(str(dag_file), default_args_config_path=str(unrelated_default_path))
+    some_dag = _DagFactory(str(dag_file), defaults_config_path=str(unrelated_default_path))
 
     result = some_dag._retrieve_possible_default_config_dirs()
     expected = [tmp_path / "config" / "a" / "b" / "c", unrelated_default_path]
@@ -721,7 +721,7 @@ def test_retrieve_possible_default_config_dirs_no_config_path(tmp_path):
     default_config_path = tmp_path / "default"
     default_config_path.mkdir()
 
-    some_dag = _DagFactory(config_filepath=None, config={"a": "b"}, default_args_config_path=str(default_config_path))
+    some_dag = _DagFactory(config_filepath=None, config_dict={"a": "b"}, defaults_config_path=str(default_config_path))
 
     result = some_dag._retrieve_possible_default_config_dirs()
     assert result == [default_config_path]
@@ -749,7 +749,7 @@ def test_default_override_based_on_directory_tree(serialize_config_md_mock, tmp_
     _write_sample_defaults(tmp_path / "a/b", "b")
     _write_sample_defaults(tmp_path / "a/b/c", "c")
 
-    some_dag = _DagFactory(str(dag_file), default_args_config_path=str(tmp_path / "a"))
+    some_dag = _DagFactory(str(dag_file), defaults_config_path=str(tmp_path / "a"))
 
     result = some_dag.build_dags()
     dag = result["second_example_dag"]


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/505

Changes `_DagFactory` class param
- `config` -> `config_dict`
- `default_args_config_path` -> `defaults_config_path`
- `default_args_config_dict ` -> `defaults_config_dict `

Changes `load_yaml_dags` param
- `default_args_config_dict` -> `default_config_dict`