### PR TITLE
Fix Pendulum compatibility issue for Airflow 2.4

### DIFF
--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -28,9 +28,19 @@ curl -sSL "$CONSTRAINT_URL" -o /tmp/constraint.txt
 sed '/PyYAML==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
 mv /tmp/constraint.txt.tmp /tmp/constraint.txt
 
+# Fix pendulum compatibility issue for Airflow 2.4
+if [ "$AIRFLOW_VERSION" = "2.4" ]; then
+  sed '/pendulum==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
+  mv /tmp/constraint.txt.tmp /tmp/constraint.txt
+fi
+
 pip install uv
 uv pip install pip --upgrade
 
+# Fix pendulum compatibility issue for Airflow 2.4
+if [ "$AIRFLOW_VERSION" = "2.4" ]; then
+  uv pip install "pendulum<3.0.0"
+fi
 
 if [ "$AIRFLOW_VERSION" = "3.0" ]; then
   uv pip install "apache-airflow>=3.0.2" --constraint /tmp/constraint.txt


### PR DESCRIPTION
### Description

This PR solves a compatibility issue between **Airflow 2.4** and **Pendulum**. Specifically, Airflow 2.4 is not fully compatible with Pendulum version 3.0.0 and above.

### Changes:

* Modified `/tmp/constraint.txt` to remove `pendulum==` version restriction.
* Added command to upgrade `pip` using `uv`.
* Installed compatible Pendulum version `<3.0.0` if Airflow 2.4 is detected.

### Why:

* Airflow 2.4 has compatibility issues with Pendulum version 3.0.0 and above. This fix ensures that the correct version of Pendulum is installed and works seamlessly with Airflow 2.4.

### Related Issues:

#550 