### PR TITLE
Update pyproject.toml to Sync Test Versions with CI/CD Pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,16 @@ dependencies = [
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10"]
 airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
+
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.11"]
+airflow = ["2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
+
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.12"]
+airflow = ["2.9", "2.10", "2.11", "3.0"]
 
 
 [tool.hatch.envs.tests.scripts]


### PR DESCRIPTION
### Description

**Update Python and Airflow versions in `pyproject.toml`**: The file has been updated to mirror the configurations in the CI pipeline. This ensures that versions like **Python 3.11** and **Airflow 2.4** are excluded in both local and CI environments.

### Changes

* Excluded Python 3.11 with Airflow versions 2.4, 2.5, and 2.6: These combinations are excluded due to compatibility issues with Python 3.11.
* Excluded Python 3.12 with Airflow versions 2.4, 2.5, 2.6, 2.7, and 2.8: Official support for Python 3.12 and corresponding constraints.txt files are available only for Apache Airflow versions >= 2.9.0. Therefore, Python 3.12 is excluded for Airflow versions prior to 2.9.0.

### Related Issues:

#552 