### PR TITLE
Fix file URI format in ObjectStoragePath example to prevent duplicate slashes

### DIFF
--- a/dev/dags/example_object_storage.py
+++ b/dev/dags/example_object_storage.py
@@ -12,5 +12,5 @@ config_file = str(CONFIG_ROOT_DIR / "example_object_storage.yml")
 
 load_yaml_dags(
     globals_dict=globals(),
-    dags_folder=config_file,
+    config_filepath=config_file,
 )

--- a/dev/dags/example_object_storage.yml
+++ b/dev/dags/example_object_storage.yml
@@ -12,4 +12,4 @@ object_storage_ops:
         my_obj_storage:
           __type__: airflow.io.path.ObjectStoragePath
           __args__:
-            - file:///$CONFIG_ROOT_DIR/data/object_storage_ops.csv
+            - file://$CONFIG_ROOT_DIR/data/object_storage_ops.csv

--- a/dev/dags/example_timetable_schedule.py
+++ b/dev/dags/example_timetable_schedule.py
@@ -12,5 +12,5 @@ config_file = str(CONFIG_ROOT_DIR / "example_timetable_schedule.yml")
 
 load_yaml_dags(
     globals_dict=globals(),
-    dags_folder=config_file,
+    config_filepath=config_file,
 )


### PR DESCRIPTION
### Description
When using `file:///` with environment variable expansion in YAML configuration, the resulting path contains duplicate slashes, causing incorrect file paths.

### Root Cause
The issue occurs in the environment variable expansion process in `dagfactory/_yaml.py`:

```python
config_with_env = os.path.expandvars(fp.read())
```

When `os.path.expandvars()` processes strings containing environment variables:

1. **With `file://`**: `file://$CONFIG_ROOT_DIR/data/file.csv` → `file:///test/path/data/file.csv` -> correct
2. **With `file:///`**: `file:///$CONFIG_ROOT_DIR/data/file.csv` → `file:////test/path/data/file.csv`  -> **wrong**

The triple slash (`///`) creates duplicate slashes after environment variable expansion, resulting in malformed file URIs.

### Solution
Change the file URI format from `file:///` to `file://` in the ObjectStoragePath example:

```yaml
# Before
- file:///$CONFIG_ROOT_DIR/data/object_storage_ops.csv

# After  
- file://$CONFIG_ROOT_DIR/data/object_storage_ops.csv
```

### Reference Issue
#536  - Original issue about ObjectStoragePath configuration
#554 - Related PR that fixes the `load_yaml_dags` parameter usage
Note: This PR contains changes related to issue #554. Please merge PR #555 first to ensure proper integration test setup.

### Testing
Now we can pass the integration test:
```yaml
tests/test_example_dags.py::test_example_dag[object_storage_ops] PASSED
```