### PR TITLE
Fix typos in scheduling and datasets docs

### DIFF
--- a/docs/configuration/schedule.md
+++ b/docs/configuration/schedule.md
@@ -27,7 +27,7 @@ Below are the supported scheduling types, each with consistent structure and exa
 
 ### 1. Cron-Based Schedule
 
-```yaml title="Corn Schedule"
+```yaml title="Cron Schedule"
 --8<-- "tests/schedule/cron.yml"
 ```
 

--- a/docs/features/datasets.md
+++ b/docs/features/datasets.md
@@ -8,7 +8,7 @@ To leverage datasets, you need to specify the `Dataset` in the `outlets` and `in
 The `outlets` and `inlets` keys should contain a list of strings representing dataset locations.
 In the `schedule` key of the consumer DAG, you can set the `Dataset` that the DAG should be scheduled against. The key
 should contain a list of dataset locations.
-The consumer DAG will run when all the specified datasets become avai
+The consumer DAG will run when all the specified datasets become available.
 
 ### Example: Outlet and Inlet
 


### PR DESCRIPTION
## Description
This PR fixes two minor documentation typos:
1. Corrects "Corn Schedule" to "Cron Schedule" in docs/configuration/schedule.md.
2. Fixes truncated word "avai" to "available" in docs/configuration/datasets.md.

**No code changes, docs only.**

## Reference Issue
resolves #564 