### PR TITLE
docs: Make markdownlint happy (fix MD007 ul-indent in dev/README.md)

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -9,7 +9,7 @@ Welcome to Astronomer! This project was generated after you ran 'astro dev init'
 Your Astro project contains the following files and folders:
 
 - dags: This folder contains the Python files for your Airflow DAGs. By default, this directory includes one example DAG:
-  - `example_astronauts`: This DAG shows a simple ETL pipeline example that queries the list of astronauts currently in space from the Open Notify API and prints a statement for each astronaut. The DAG uses the TaskFlow API to define tasks in Python, and dynamic task mapping to dynamically print a statement for each astronaut. For more on how this DAG works, see our [Getting started tutorial](https://www.astronomer.io/docs/learn/get-started-with-airflow).
+    - `example_astronauts`: This DAG shows a simple ETL pipeline example that queries the list of astronauts currently in space from the Open Notify API and prints a statement for each astronaut. The DAG uses the TaskFlow API to define tasks in Python, and dynamic task mapping to dynamically print a statement for each astronaut. For more on how this DAG works, see our [Getting started tutorial](https://www.astronomer.io/docs/learn/get-started-with-airflow).
 - Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.
 - include: This folder contains any additional files that you want to include as part of your project. It is empty by default.
 - packages.txt: Install OS-level packages needed for your project by adding them to this file. It is empty by default.


### PR DESCRIPTION
## Description
Fixes markdownlint violation (MD007/ul-indent) in `dev/README.md`.

## Changes
- Adjusted unordered list indentation from 2 spaces to 4 spaces.
- Verified with `pre-commit run --all-files` that markdownlint now passes.

## Notes
**Docs-only change. No code modified. It won't breaks the appearance of dev/README.md**