### PR TITLE
Allow yaml/yml suffix for shared defaults

### DIFF
--- a/dagfactory/constants.py
+++ b/dagfactory/constants.py
@@ -4,4 +4,4 @@ TELEMETRY_TIMEOUT = 1.0
 
 AIRFLOW3_MAJOR_VERSION = 3
 
-DEFAULTS_FILE_NAMES = ["defaults.yml", "defaults"]
+DEFAULTS_FILE_NAMES = ["defaults.yml", "defaults.yaml"]

--- a/dagfactory/constants.py
+++ b/dagfactory/constants.py
@@ -4,4 +4,4 @@ TELEMETRY_TIMEOUT = 1.0
 
 AIRFLOW3_MAJOR_VERSION = 3
 
-DEFAULTS_FILE_NAME = "defaults.yml"
+DEFAULTS_FILE_NAMES = ["defaults.yml", "defaults"]

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -15,7 +15,7 @@ except ImportError:
     from airflow.models import DAG
 
 from dagfactory._yaml import load_yaml_file
-from dagfactory.constants import DEFAULTS_FILE_NAME
+from dagfactory.constants import DEFAULTS_FILE_NAMES
 from dagfactory.dagbuilder import DagBuilder
 from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
 
@@ -110,14 +110,16 @@ class _DagFactory:
     def _retrieve_default_yaml_filepaths(self):
         """
         Return the paths to existing `defaults.yml` files relevant to run the YAML DAG of interest.
-        The YAML filepahts are sorted by priority, with the top-priority directory being the first element.
+        The YAML filepaths are sorted by priority, with the top-priority directory being the first element.
         """
         default_yaml_filepaths = []
         possible_default_yml_dirs = self._retrieve_possible_default_config_dirs()
         for default_yml_dir in possible_default_yml_dirs:
-            default_yml_filepath = default_yml_dir / DEFAULTS_FILE_NAME
-            if default_yml_filepath.exists():
-                default_yaml_filepaths.append(default_yml_filepath)
+            for default_file_name in DEFAULTS_FILE_NAMES:
+                default_yml_filepath = default_yml_dir / default_file_name
+                if default_yml_filepath.exists():
+                    default_yaml_filepaths.append(default_yml_filepath)
+                    break  # Only use the first one found (yml preferred over yaml)
         return default_yaml_filepaths
 
     def _retrieve_default_config_list(self):

--- a/docs/configuration/defaults.md
+++ b/docs/configuration/defaults.md
@@ -6,7 +6,7 @@ DAG Factory allows you to define default values for DAG-level arguments and Airf
 - Define the `default_args` within each DAG definition in the DAGs YAML file;
 - Declare a `default` block within the toplevel of the DAGs YAML file;
 - Define the `default_args_config_dict` argument when instantiating the `DAGFactory` class;
-- Create one or multiple `defaults.yml` and declare the `default_args_config_path` argument in the `DAGFactory` class. This approach includes support for combining multiple `defaults.yml` files.
+- Create one or multiple `defaults.yml` or `defaults.yaml` and declare the `default_args_config_path` argument in the `DAGFactory` class. This approach includes support for combining multiple `defaults.yml` or `defaults.yaml` files.
 
 Although you cannot use the last two configurations together, you can use a combination of the first two configurations with either the third or the last.
 
@@ -77,7 +77,7 @@ It allows you to define DAG-level arguments, including the `default_args`, using
 --8<-- "dev/dags/example_dag_factory_default_config_dict.py:13:19"
 ```
 
-## Declaring default values using the `defaults.yml` file
+## Declaring default values using the `defaults.yml` or `defaults.yaml` file
 
 This configuration affects DAGs created using the `DagFactory` class without the `default_args_config_dict` argument.
 
@@ -154,3 +154,6 @@ Given the various ways to specify top-level DAG arguments, including `default_ar
 2. In the `default` block within the workflow's YAML file
 3. The arguments defined in `default_args_config_dict`
 4. If (3) is not declared, the `defaults.yml` hierarchy.
+
+!!! note
+    The `defaults.yml` is preferred over `defaults.yaml`.

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -737,7 +737,7 @@ def _write_sample_defaults(path: Path, identifier: str, defaults_file: str):
         yaml.dump(data, fp)
 
 
-@pytest.mark.parametrize("defaults_file", ["defaults.ymm", "defaults.yam"])
+@pytest.mark.parametrize("defaults_file", ["defaults.yml", "defaults.yaml"])
 @patch("dagfactory.dagfactory._DagFactory._serialise_config_md")
 def test_default_override_based_on_directory_tree(serialize_config_md_mock, tmp_path, defaults_file):
     # Create structure: tmp_path/a/b/c/dag.yml

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -727,27 +727,28 @@ def test_retrieve_possible_default_config_dirs_no_config_path(tmp_path):
     assert result == [default_config_path]
 
 
-def _write_sample_defaults(path: Path, identifier: str):
+def _write_sample_defaults(path: Path, identifier: str, defaults_file: str):
     data = {
         "default_args": {"owner": identifier, f"{identifier}_param": identifier},
         "tags": [identifier],
         f"{identifier}_dag_param": identifier,
     }
-    with open(path / "defaults.yml", "w") as fp:
+    with open(path / defaults_file, "w") as fp:
         yaml.dump(data, fp)
 
 
+@pytest.mark.parametrize("defaults_file", ["defaults.ymm", "defaults.yam"])
 @patch("dagfactory.dagfactory._DagFactory._serialise_config_md")
-def test_default_override_based_on_directory_tree(serialize_config_md_mock, tmp_path):
+def test_default_override_based_on_directory_tree(serialize_config_md_mock, tmp_path, defaults_file):
     # Create structure: tmp_path/a/b/c/dag.yml
     dag_path = tmp_path / "a/b/c"
     dag_path.mkdir(parents=True)
     dag_file = dag_path / "dag.yml"
     shutil.copyfile(DAG_FACTORY_VARIABLES_AS_ARGUMENTS, str(dag_file))
 
-    _write_sample_defaults(tmp_path / "a", "a")
-    _write_sample_defaults(tmp_path / "a/b", "b")
-    _write_sample_defaults(tmp_path / "a/b/c", "c")
+    _write_sample_defaults(tmp_path / "a", "a", defaults_file)
+    _write_sample_defaults(tmp_path / "a/b", "b", defaults_file)
+    _write_sample_defaults(tmp_path / "a/b/c", "c", defaults_file)
 
     some_dag = _DagFactory(str(dag_file), defaults_config_path=str(tmp_path / "a"))
 


### PR DESCRIPTION
closes: https://github.com/astronomer/dag-factory/issues/441

This PR enable support for the suffix `yaml` and `yml` for the default file. Before this PR, only `yml` was supported. The `yml` extension will be preferred over `yaml`