### PR TITLE
CI: Only build docs on PR push event and deploy for merge and release

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -256,8 +256,10 @@ jobs:
     needs:
       - Authorize
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: true
       - name: Install uv
         uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
       - name: Set up Python

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, fix_docs_job]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -251,6 +251,8 @@ jobs:
   Build-Mkdocs:
     name: Build MkDocs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - Authorize
     steps:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -250,13 +250,15 @@ jobs:
   build-mkdocs:
     name: Build MkDocs
     runs-on: ubuntu-latest
+    needs:
+      - Authorize
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-#        - name: Install uv
-#          uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
-#          with:
-#            version: "0.7.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
+        with:
+          version: "0.7.12"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -315,6 +317,7 @@ jobs:
       - Deploy-Pages
       - Code-Coverage
       - Authorize
+      - build-mkdocs
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -247,25 +247,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 
-  build-docs:
-    build-mkdocs:
-      name: Build MkDocs
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v5
+  build-mkdocs:
+    name: Build MkDocs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
 #        - name: Install uv
 #          uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
 #          with:
 #            version: "0.7.12"
-        - name: Set up Python
-          uses: actions/setup-python@v5
-          with:
-            python-version: "3.12"
-        - name: Install hatch via uv
-          run: uv tool install hatch
-        - name: Build docs (MkDocs)
-          run: hatch run docs:build
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install hatch via uv
+        run: uv tool install hatch
+      - name: Build docs (MkDocs)
+        run: hatch run docs:build
 
   Publish-Package:
     if: github.event_name == 'release'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -266,6 +266,45 @@ jobs:
       - name: Build docs (MkDocs)
         run: hatch run docs:build
 
+  Deploy-Pages:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - Authorize
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
+        with:
+          version: "0.7.12"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          architecture: "x64"
+
+      - name: Install packages and dependencies
+        run: uv tool install hatch
+
+      - name: Deploy Docs
+        run: |
+          git config user.name "oss-integrations-bot"
+          git config user.email "oss-integrations-bot@astronomer.io"
+
+          git fetch origin gh-pages --depth=1
+
+          if [[ $GITHUB_EVENT_NAME == "release" ]]; then
+              hatch run docs:gh-release
+          else
+              hatch run docs:gh-deploy
+          fi
+
   Publish-Package:
     if: github.event_name == 'release'
     name: Build and publish Python 🐍 distributions 📦 to PyPI

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -208,6 +208,7 @@ jobs:
     needs:
       - Run-Unit-Tests
       - Run-Integration-Tests
+      - Build-Mkdocs
       - Authorize
     runs-on: ubuntu-latest
     permissions:
@@ -247,7 +248,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 
-  build-mkdocs:
+  Build-Mkdocs:
     name: Build MkDocs
     runs-on: ubuntu-latest
     needs:
@@ -257,8 +258,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
-        with:
-          version: "0.7.12"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -317,7 +316,7 @@ jobs:
       - Deploy-Pages
       - Code-Coverage
       - Authorize
-      - build-mkdocs
+      - Build-Mkdocs
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, fix_docs_job]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to
@@ -247,46 +247,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 
-  Deploy-Pages:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    needs:
-      - Static-Check
-      - Run-Unit-Tests
-      - Run-Integration-Tests
-      - Authorize
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
-        with:
-          version: "0.7.12"
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          architecture: "x64"
-
-      - name: Install packages and dependencies
-        run: uv tool install hatch
-
-      - name: Deploy Docs
-        run: |
-          git config user.name "oss-integrations-bot"
-          git config user.email "oss-integrations-bot@astronomer.io"
-
-          git fetch origin gh-pages --depth=1
-
-          if [[ $GITHUB_EVENT_NAME == "release" ]]; then
-              hatch run docs:gh-release
-          else
-              hatch run docs:gh-deploy
-          fi
+  build-docs:
+    build-mkdocs:
+      name: Build MkDocs
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v5
+#        - name: Install uv
+#          uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
+#          with:
+#            version: "0.7.12"
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.12"
+        - name: Install hatch via uv
+          run: uv tool install hatch
+        - name: Build docs (MkDocs)
+          run: hatch run docs:build
 
   Publish-Package:
     if: github.event_name == 'release'

--- a/README.md
+++ b/README.md
@@ -19,14 +19,19 @@ The minimum requirements for **dag-factory** are:
 For a gentle introduction, please take a look at our [Quickstart Guide](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/). For more examples, please see the
 [examples](/examples) folder.
 
-- [Quickstart](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-astro-cli/)
+- Quickstart
+    - [Astro CLI](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-astro-cli/)
+    - [Airflow Standalone](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/)
 - [Benefits](#benefits)
-- [Features](https://astronomer.github.io/dag-factory/latest/features/dynamic_tasks/)
+- Features
+    - [load_yml_dags Function](https://astronomer.github.io/dag-factory/latest/configuration/load_yaml_dags/)
+    - [Schedule](https://astronomer.github.io/dag-factory/latest/configuration/schedule/)
     - [Dynamically Mapped Tasks](https://astronomer.github.io/dag-factory/latest/features/dynamic_tasks/)
-    - [Multiple Configuration Files](https://astronomer.github.io/dag-factory/latest/features/multiple_configuration_files/)
-    - [Callbacks](https://astronomer.github.io/dag-factory/latest/features/callbacks/)
+    - [Define Python Object](https://astronomer.github.io/dag-factory/latest/configuration/custom_py_object/)
     - [Custom Operators](https://astronomer.github.io/dag-factory/latest/features/custom_operators/)
-    - [HttpSensor](https://astronomer.github.io/dag-factory/latest/features/http_task/)
+    - [Defaults](https://astronomer.github.io/dag-factory/latest/configuration/defaults/)
+    - [Callbacks](https://astronomer.github.io/dag-factory/latest/features/callbacks/)
+    - [KubernetesPodOperator](https://astronomer.github.io/dag-factory/latest/features/kpo/)
 - [Contributing](https://astronomer.github.io/dag-factory/latest/contributing/howto/)
 
 ## Benefits
@@ -35,6 +40,16 @@ For a gentle introduction, please take a look at our [Quickstart Guide](https://
 - Construct DAGs without learning Airflow primitives
 - Avoid duplicative code
 - Everyone loves YAML! ;)
+
+## 📢 Dag-Factory 1.0 Released
+
+Version **1.0** introduces important improvements and breaking changes to support modern Airflow usage.
+
+👉 See the [Migration Guide](./docs/migration_guide.md) to upgrade from earlier versions.
+
+## 🚀 Dag-Factory Supports Airflow 3
+
+DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,14 @@ The minimum requirements for **dag-factory** are:
 For a gentle introduction, please take a look at our [Quickstart Guide](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/). For more examples, please see the
 [examples](/examples) folder.
 
-- Quickstart
-    - [Astro CLI](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-astro-cli/)
-    - [Airflow Standalone](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/)
+- [Quickstart](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-astro-cli/)
 - [Benefits](#benefits)
-- Features
-    - [load_yml_dags Function](https://astronomer.github.io/dag-factory/latest/configuration/load_yaml_dags/)
-    - [Schedule](https://astronomer.github.io/dag-factory/latest/configuration/schedule/)
+- [Features](https://astronomer.github.io/dag-factory/latest/features/dynamic_tasks/)
     - [Dynamically Mapped Tasks](https://astronomer.github.io/dag-factory/latest/features/dynamic_tasks/)
-    - [Define Python Object](https://astronomer.github.io/dag-factory/latest/configuration/custom_py_object/)
-    - [Custom Operators](https://astronomer.github.io/dag-factory/latest/features/custom_operators/)
-    - [Defaults](https://astronomer.github.io/dag-factory/latest/configuration/defaults/)
+    - [Multiple Configuration Files](https://astronomer.github.io/dag-factory/latest/features/multiple_configuration_files/)
     - [Callbacks](https://astronomer.github.io/dag-factory/latest/features/callbacks/)
-    - [KubernetesPodOperator](https://astronomer.github.io/dag-factory/latest/features/kpo/)
+    - [Custom Operators](https://astronomer.github.io/dag-factory/latest/features/custom_operators/)
+    - [HttpSensor](https://astronomer.github.io/dag-factory/latest/features/http_task/)
 - [Contributing](https://astronomer.github.io/dag-factory/latest/contributing/howto/)
 
 ## Benefits
@@ -40,16 +35,6 @@ For a gentle introduction, please take a look at our [Quickstart Guide](https://
 - Construct DAGs without learning Airflow primitives
 - Avoid duplicative code
 - Everyone loves YAML! ;)
-
-## 📢 Dag-Factory 1.0 Released
-
-Version **1.0** introduces important improvements and breaking changes to support modern Airflow usage.
-
-👉 See the [Migration Guide](./docs/migration_guide.md) to upgrade from earlier versions.
-
-## 🚀 Dag-Factory Supports Airflow 3
-
-DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
 ## License
 

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -2,7 +2,7 @@
 
 from .dagfactory import load_yaml_dags
 
-__version__ = "0.23.0"
+__version__ = "1.0.0a3"
 __all__ = [
     "load_yaml_dags",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ dependencies = [
 dev = "mkdocs build && mkdocs serve" # For local development and preventing publishing
 gh-deploy = "python scripts/docs_deploy.py dev"
 gh-release = "python scripts/docs_deploy.py release"
+build = "mkdocs build --strict"
 
 ######################################
 # THIRD PARTY TOOLS


### PR DESCRIPTION
After removing the pull_request_target event and introducing the Authorize job, the Deploy-Pages CI job no longer runs as expected.

This PR fixes that by:
- Ensuring the Deploy-Pages job runs only on merges to main or when a release is published.
- Running the Build-MkDocs job on every push to perform a sanity check on the documentation build.

CI: https://github.com/astronomer/dag-factory/actions/runs/17207460971/job/48811112735

closes: https://github.com/astronomer/dag-factory/issues/481 
closes: https://github.com/astronomer/dag-factory/issues/470