### PR TITLE
docs: remove trailing slash from AIRFLOW_HOME example

### DIFF
--- a/docs/contributing/howto.md
+++ b/docs/contributing/howto.md
@@ -95,7 +95,7 @@ Once you're set up with uv, you can use these helpful commands:
    Disable loading Airflow standard example DAGs:
 
 ```bash
-export AIRFLOW_HOME=$(pwd)/dev/
+export AIRFLOW_HOME=$(pwd)/dev
 export AIRFLOW__CORE__LOAD_EXAMPLES=false
 ```
 


### PR DESCRIPTION
Without this, `CONFIG_ROOT_DIR=$AIRFLOW_HOME/dags` expands to `$(pwd)/dev//dags`; this removes trailing slash so derived paths stay clean and consistent with the rest of the docs (docs-only change).

---

Before:
export AIRFLOW_HOME=$(pwd)/dev/

After:
export AIRFLOW_HOME=$(pwd)/dev


