### PR TITLE
Restrict the hatch version to fix the CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, fix_ci]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
-      - run: uv tool install hatch "click!=8.3.0"
+      - run: uv pip install "hatch" "click!=8.3.0"
       - run: hatch run tests.py3.12-2.10:static-check
 
   Run-Unit-Tests:
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv tool install hatch "click!=8.3.0"
+          uv pip install "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv tool install hatch "click!=8.3.0"
+          uv pip install "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -267,7 +267,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install hatch via uv
-        run: uv tool install hatch "click!=8.3.0"
+        run: uv pip install "hatch" "click!=8.3.0"
       - name: Build docs (MkDocs)
         run: hatch run docs:build
 
@@ -295,7 +295,7 @@ jobs:
           architecture: "x64"
 
       - name: Install packages and dependencies
-        run: uv tool install hatch "click!=8.3.0"
+        run: uv pip install "hatch" "click!=8.3.0"
 
       - name: Deploy Docs
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
-      - run: uv pip install --system "hatch" "click!=8.3.0"
+      - run: uv pip install --system "hatch>=1.14.2"
       - run: hatch run tests.py3.12-2.10:static-check
 
   Run-Unit-Tests:
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv pip install  --system "hatch" "click!=8.3.0"
+          uv pip install  --system "hatch>=1.14.2"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv pip install --system "hatch" "click!=8.3.0"
+          uv pip install --system "hatch>=1.14.2"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -267,7 +267,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install hatch via uv
-        run: uv pip install --system "hatch" "click!=8.3.0"
+        run: uv pip install --system "hatch>=1.14.2"
       - name: Build docs (MkDocs)
         run: hatch run docs:build
 
@@ -295,7 +295,7 @@ jobs:
           architecture: "x64"
 
       - name: Install packages and dependencies
-        run: uv pip install --system "hatch" "click!=8.3.0"
+        run: uv pip install --system "hatch>=1.14.2"
 
       - name: Deploy Docs
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, fix_ci]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
-      - run: uv tool install hatch
+      - run: uv tool install hatch "click!=8.3.0"
       - run: hatch run tests.py3.12-2.10:static-check
 
   Run-Unit-Tests:
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv tool install hatch
+          uv tool install hatch "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv tool install hatch
+          uv tool install hatch "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -267,7 +267,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install hatch via uv
-        run: uv tool install hatch
+        run: uv tool install hatch "click!=8.3.0"
       - name: Build docs (MkDocs)
         run: hatch run docs:build
 
@@ -295,7 +295,7 @@ jobs:
           architecture: "x64"
 
       - name: Install packages and dependencies
-        run: uv tool install hatch
+        run: uv tool install hatch "click!=8.3.0"
 
       - name: Deploy Docs
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
-      - run: uv pip install "hatch" "click!=8.3.0"
+      - run: uv pip install --system "hatch" "click!=8.3.0"
       - run: hatch run tests.py3.12-2.10:static-check
 
   Run-Unit-Tests:
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv pip install "hatch" "click!=8.3.0"
+          uv pip install  --system "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          uv pip install "hatch" "click!=8.3.0"
+          uv pip install --system "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -267,7 +267,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install hatch via uv
-        run: uv pip install "hatch" "click!=8.3.0"
+        run: uv pip install --system "hatch" "click!=8.3.0"
       - name: Build docs (MkDocs)
         run: hatch run docs:build
 
@@ -295,7 +295,7 @@ jobs:
           architecture: "x64"
 
       - name: Install packages and dependencies
-        run: uv pip install "hatch" "click!=8.3.0"
+        run: uv pip install --system "hatch" "click!=8.3.0"
 
       - name: Deploy Docs
         run: |


### PR DESCRIPTION
This PR updates the CI workflow to fix installation errors caused by `click==8.3.0`.

- Replaces the command `uv tool install hatch` with:
  ```bash
  uv pip install --system "hatch>=1.14.2"
