### PR TITLE
feat: support `key: +{task}[{xcom_key}]` use

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -811,7 +811,6 @@ class DagBuilder:
         dag_kwargs["dagrun_timeout"] = dag_params.get("dagrun_timeout", None)
 
         if INSTALLED_AIRFLOW_VERSION.major < AIRFLOW3_MAJOR_VERSION:
-
             dag_kwargs["default_view"] = dag_params.get(
                 "default_view", configuration.conf.get("webserver", "dag_default_view")
             )
@@ -1089,10 +1088,7 @@ class DagBuilder:
         for arg_key, arg_value in task_params.items():
             if arg_key in callable_args_keys:
                 decorator_kwargs.pop(arg_key)
-                if isinstance(arg_value, str) and arg_value.startswith("+"):
-                    upstream_task_name = arg_value.split("+")[-1]
-                    callable_kwargs[arg_key] = tasks_dict[upstream_task_name]
-                else:
+                if not DagBuilder._replace_kwargs_values_as_xcom(callable_kwargs, arg_key, arg_value, tasks_dict):
                     callable_kwargs[arg_key] = arg_value
 
         expand_kwargs = decorator_kwargs.pop("expand", {})
@@ -1113,11 +1109,28 @@ class DagBuilder:
             return decorator(**decorator_kwargs)(**callable_kwargs)
 
     @staticmethod
+    def _replace_kwargs_values_as_xcom(kwargs: dict(str, Any), key: str, value: Any, tasks_dict: dict(str, Any)):
+        # Match with multiple_outputs=True case with {key}: +{task}["{xcom_key}"]
+        _PATTERN = re.compile(r"^\+(?P<task>\w*)(\[['\"](?P<xcom_key>.*)['\"]\])?$")
+
+        if not isinstance(value, str):
+            return False
+
+        m = _PATTERN.match(value)
+        if m:
+            task = m.group("task")
+            xcom_key = m.group("xcom_key")
+            if not xcom_key:
+                kwargs[key] = tasks_dict[task]
+            else:
+                kwargs[key] = tasks_dict[task][xcom_key]
+            return True
+        return False
+
+    @staticmethod
     def replace_kwargs_values_as_tasks(kwargs: dict(str, Any), tasks_dict: dict(str, Any)):
         for key, value in kwargs.items():
-            if isinstance(value, str) and value.startswith("+"):
-                upstream_task_name = value.split("+")[-1]
-                kwargs[key] = tasks_dict[upstream_task_name]
+            DagBuilder._replace_kwargs_values_as_xcom(kwargs, key, value, tasks_dict)
 
     @staticmethod
     def set_callback(parameters: Union[dict, str], callback_type: str, has_name_and_file=False) -> Callable:

--- a/dev/dags/example_multiple_outputs_taskflow.yml
+++ b/dev/dags/example_multiple_outputs_taskflow.yml
@@ -1,0 +1,18 @@
+example_multiple_outputs_taskflow:
+  schedule: null
+  render_template_as_native_obj: True
+  catchup: false
+  tags: [example, test]
+  tasks:
+    - task_id: collect
+      multiple_outputs: true
+      decorator: airflow.decorators.task
+      python_callable: sample.collect
+    - task_id: echo1
+      decorator: airflow.decorators.task
+      python_callable: sample.echo
+      value: "+collect['key1']"
+    - task_id: echo2
+      decorator: airflow.decorators.task
+      python_callable: sample.echo
+      value: "+collect['key2']"

--- a/dev/dags/sample.py
+++ b/dev/dags/sample.py
@@ -10,6 +10,19 @@ except ImportError:
     from airflow.operators.python import get_current_context
 
 
+from airflow.utils.context import Context
+
+
+def collect(**context: Context):
+    return {"key1": "value1", "key2": "value2"}
+
+
+def echo(value):
+    print(value)
+    return value
+
+
+
 def build_numbers_list():
     return [2, 4, 6]
 

--- a/docs/features/taskflow_pipeline.md
+++ b/docs/features/taskflow_pipeline.md
@@ -1,0 +1,38 @@
+## TaskFlow Pipeline with `multiple_outputs=True`
+
+DAG Factory supports Airflow’s
+[Pythonic Dags with the TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html),
+enabling "getitem" shorthand for TaskFlow-style decorated tasks that return mappings (multiple_outputs=True).
+
+### What it enables
+
+- When a TaskFlow-decorated task returns a dict (for example, using `multiple_outputs=True`), downstream task arguments can reference either the whole returned mapping or a single key from it using a concise syntax.
+
+### Syntax
+
+- `+task_id` (with default `multiple_outputs=False`) — reference the entire Python function return value (the pushed value from the task). This is useful when the upstream task returns a mapping and the downstream callable expects the return_value.
+- `+task_id['key']` or `+task_id["key"]` — reference a single value from the mapping returned by the upstream TaskFlow task.
+
+### Examples
+
+Given a TaskFlow task `collect` that returns a multiple_outputs dict like:
+
+```
+@task(multiple_ouputs=True)
+def collect(**context):
+    return {"key1": "value1", "key2": "value2"}
+```
+
+It's representation in dag_factory yaml is like
+```
+- task_id: collect
+  multiple_outputs: true
+  decorator: airflow.decorators.task
+  python_callable: sample.collect
+```
+
+Then you can use a single value from the mapping with:
+
+```
+value: "+collect['key1']"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Are you new to DAG Factory? This is the place to start!
 ## Features
 
 - [Dynamic tasks](features/dynamic_tasks.md)
+- [TaskFlow Pipeline](features/taskflow_pipeline.md)
 - [Callbacks](features/callbacks.md)
 - [Custom operators](features/custom_operators.md)
 - [Multiple configuration files](features/multiple_configuration_files.md)


### PR DESCRIPTION
Airflow supports use of {decorated_task}[{xcom_key}] for xcoms that are not return_value [link](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html#the-big-picture-a-taskflow-pipeline)

Here I support for fetching upstream task's xcom from decorated task with `multiple_outputs=True`

The following example has already been tested in Airflow 3.1.0 (and should also works in Airflow 3)

```
example_multiple_outputs_taskflow:
  schedule: null
  render_template_as_native_obj: True
  catchup: false
  tags: [example, test]
  tasks:
    - task_id: collect
      multiple_outputs: true
      decorator: airflow.decorators.task
      python_callable: sample.collect
    - task_id: echo1
      decorator: airflow.decorators.task
      python_callable: sample.echo
      value: "+collect['key1']"
    - task_id: echo2
      decorator: airflow.decorators.task
      python_callable: sample.echo
      value: "+collect['key2']"
```