### PR TITLE
fix: support DatasetAlias in outlets

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -998,7 +998,10 @@ class DagBuilder:
                         datasets_uri = task_params[key]
 
                     if key in task_params and datasets_uri:
-                        task_params[key] = [Dataset(uri) for uri in datasets_uri]
+                        task_params[key] = [
+                            Dataset(uri) if isinstance(uri, str) else uri
+                            for uri in datasets_uri
+                        ]
 
     @staticmethod
     def make_decorator(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -998,10 +998,7 @@ class DagBuilder:
                         datasets_uri = task_params[key]
 
                     if key in task_params and datasets_uri:
-                        task_params[key] = [
-                            Dataset(uri) if isinstance(uri, str) else uri
-                            for uri in datasets_uri
-                        ]
+                        task_params[key] = [Dataset(uri) if isinstance(uri, str) else uri for uri in datasets_uri]
 
     @staticmethod
     def make_decorator(

--- a/dev/dags/datasets/example_dag_datasets.yml
+++ b/dev/dags/datasets/example_dag_datasets.yml
@@ -77,3 +77,16 @@ example_without_custom_config_condition_dataset_consumer_dag:
     - task_id: "task_1"
       operator: airflow.operators.bash.BashOperator
       bash_command: "echo 'consumer datasets'"
+
+example_simple_dataset_alias_dag:
+  description: "Example DAG simple datasets alias"
+  schedule: "0 5 * * *"
+  catchup: false
+  tasks:
+    - task_id: "task_1"
+      operator: airflow.operators.bash.BashOperator
+      bash_command: "echo 'may set dynamic_outputs'"
+      inlets: [ 's3://bucket_example/raw/dataset1_source.json' ]
+      outlets:
+        - __type__: airflow.datasets.DatasetAlias
+          name: "dynamic_outputs"


### PR DESCRIPTION
In current version, all outlets should be only uri of Datasets, but airflow support DatasetAlias class in outlets/inlets
Changed object cast, it allows set object type in yaml.
```
      outlets:
        - __type__: airflow.datasets.DatasetAlias
          name: "dynamic_outputs"
```