### PR TITLE
Pin structlog to fix the deploy docs job

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -272,7 +272,7 @@ jobs:
         run: hatch run docs:build
 
   Deploy-Pages:
-    # if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, fix_docs_ci]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to
@@ -272,7 +272,7 @@ jobs:
         run: hatch run docs:build
 
   Deploy-Pages:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
+    # if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, fix_docs_ci]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,10 @@ dependencies = [
     "mike",
     "pymdown-extensions",
     "mkdocs-material",
+    # TODO: Remove it once Airflow 3.1.2 available
+    # Issue: https://github.com/hynek/structlog/issues/769
+    "structlog<25.5.0",
+
 ]
 
 [tool.hatch.envs.docs.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,6 @@ dependencies = [
     # TODO: Remove it once Airflow 3.1.2 available
     # Issue: https://github.com/hynek/structlog/issues/769
     "structlog<25.5.0",
-
 ]
 
 [tool.hatch.envs.docs.scripts]


### PR DESCRIPTION
The Deploy Docs GitHub Action is currently failing on the main branch due to an incompatibility between Airflow’s logging utilities and the latest structlog release.

This PR pins structlog to a compatible version to temporarily bypass the issue until an official Airflow fix is released.

CI: https://github.com/astronomer/dag-factory/actions/runs/18935700797/job/54061953915?pr=608