### PR TITLE
Add support for `.airflowignore` file to exclude specific YAML files

### DIFF
--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -379,8 +379,15 @@ def _compile_airflowignore_regex(pattern: str) -> re.Pattern[str]:
 def _matches_airflowignore_patterns(path: str, patterns: List[str]) -> Optional[bool]:
     """Return the last matching gitignore-style decision for a scoped relative path."""
     spec = _compile_airflowignore_spec(tuple(patterns))
-    include, _index = GitIgnoreSpec._match_file(enumerate(spec.patterns), path)
-    return include
+    decision: Optional[bool] = None
+
+    for pattern in spec.patterns:
+        if pattern.include is None:
+            continue
+        if pattern.match_file(path):
+            decision = pattern.include
+
+    return decision
 
 
 def _matches_airflowignore_regex(path: str, patterns: List[str]) -> bool:
@@ -418,7 +425,6 @@ def _should_ignore_file(file_path: Path, dags_folder: Path, ignore_patterns_by_d
     :rtype: bool
     """
     return _should_ignore_path(file_path, dags_folder, ignore_patterns_by_dir)
-
 
 
 def _should_ignore_path(path: Path, dags_folder: Path, ignore_patterns_by_dir: Dict[Path, List[str]]) -> bool:

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -1,14 +1,15 @@
 """Module contains code for loading a DagFactory config and generating DAGs"""
 
-import fnmatch
 import logging
 import os
-from itertools import chain
+import re
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import yaml
 from airflow.configuration import conf as airflow_conf
+from pathspec.gitignore import GitIgnoreSpec
 
 try:
     from airflow.sdk.definitions.dag import DAG
@@ -33,7 +34,7 @@ class _DagFactory:
     :type config_filepath: str
     :param config_dict: DAG factory config dictionary. Cannot be used with `config_filepath`.
     :type config_dict: dict
-    :param defaults_config_path: The path to a file that contains the default arguments for that DAG.
+    :param defaults_config_path: The root directory to search for defaults.yml/defaults.yaml files.
     :type defaults_config_path: str
     :param defaults_config_dict: A dictionary of default arguments for that DAG, as an alternative to defaults_config_path.
     :type defaults_config_dict: dict
@@ -274,31 +275,15 @@ class _DagFactory:
         self.register_dags(dags, globals)
 
 
-def _load_airflowignore(dags_folder: str) -> List[str]:
-    """
-    Loads ignore patterns from .airflowignore file in the dags folder.
-
-    The .airflowignore file follows the same format as Airflow's .airflowignore:
-    - Each line contains a pattern to ignore
-    - Empty lines and lines starting with # are ignored
-    - Patterns support glob-style wildcards
-
-    :param dags_folder: Path to the DAGs folder
-    :type dags_folder: str
-    :returns: List of ignore patterns
-    :rtype: List[str]
-    """
+def _read_airflowignore(ignore_file: Path) -> List[str]:
+    """Load ignore patterns from a single .airflowignore file."""
     ignore_patterns: List[str] = []
-    ignore_file = Path(dags_folder) / ".airflowignore"
-
-    if not ignore_file.exists():
-        return ignore_patterns
 
     try:
         with open(ignore_file, "r", encoding="utf-8") as f:
             for line in f:
-                pattern = line.strip()
-                if pattern and not pattern.startswith("#"):
+                pattern = line.split("#", 1)[0].strip()
+                if pattern:
                     ignore_patterns.append(pattern)
     except (OSError, IOError) as e:
         logging.warning("Failed to read .airflowignore file at %s: %s", ignore_file, e)
@@ -306,11 +291,118 @@ def _load_airflowignore(dags_folder: str) -> List[str]:
     return ignore_patterns
 
 
-def _should_ignore_file(file_path: Path, dags_folder: Path, ignore_patterns: List[str]) -> bool:
+def _iter_dags_folder_contents(dags_folder: Path) -> Iterator[Tuple[Path, List[str], List[str]]]:
+    """Yield directory contents while following symlinked directories once."""
+    visited_dirs = set()
+    ignore_patterns_by_dir: Dict[Path, List[str]] = {}
+
+    for root, dirs, files in os.walk(dags_folder, topdown=True, followlinks=True):
+        root_path = Path(root)
+
+        try:
+            resolved_root = root_path.resolve(strict=False)
+        except OSError:
+            resolved_root = root_path.absolute()
+
+        if resolved_root in visited_dirs:
+            dirs[:] = []
+            continue
+
+        visited_dirs.add(resolved_root)
+        dirs.sort()
+        files.sort()
+
+        if ".airflowignore" in files:
+            ignore_file = root_path / ".airflowignore"
+            ignore_patterns_by_dir[ignore_file.parent] = _read_airflowignore(ignore_file)
+
+        dirs[:] = [
+            subdir
+            for subdir in dirs
+            if not _should_ignore_path(root_path / subdir, dags_folder, ignore_patterns_by_dir)
+        ]
+
+        yield root_path, dirs, files
+
+
+def _load_airflowignore(dags_folder: str) -> Dict[Path, List[str]]:
+    """
+    Loads ignore patterns from .airflowignore files in the dags folder tree.
+
+    The .airflowignore file follows the same format as Airflow's .airflowignore:
+    - Each line contains a pattern to ignore
+    - Empty lines and inline comments starting with # are ignored
+    - Patterns support glob-style wildcards
+    - Nested .airflowignore files are applied relative to the directory that contains them
+    - Symlinked directories are traversed during discovery
+
+    :param dags_folder: Path to the DAGs folder
+    :type dags_folder: str
+    :returns: Mapping of directories to ignore patterns from .airflowignore files
+    :rtype: Dict[Path, List[str]]
+    """
+    dags_folder_path = Path(dags_folder)
+    ignore_patterns: Dict[Path, List[str]] = {}
+
+    for root_path, _dirs, files in _iter_dags_folder_contents(dags_folder_path):
+        if ".airflowignore" not in files:
+            continue
+
+        ignore_file = root_path / ".airflowignore"
+        ignore_patterns[ignore_file.parent] = _read_airflowignore(ignore_file)
+
+    return ignore_patterns
+
+
+def _lexical_relative_path(path: Path, root: Path) -> str:
+    """Return a lexical POSIX-style path relative to root without resolving symlinks."""
+    return Path(os.path.abspath(path)).relative_to(Path(os.path.abspath(root))).as_posix()
+
+
+def _get_dag_ignore_file_syntax() -> str:
+    """Return the configured Airflow ignore syntax, defaulting to glob."""
+    return airflow_conf.get("core", "dag_ignore_file_syntax", fallback="glob").lower()
+
+
+@lru_cache(maxsize=None)
+def _compile_airflowignore_spec(patterns: tuple[str, ...]) -> GitIgnoreSpec:
+    """Compile .airflowignore patterns using gitwildmatch semantics."""
+    return GitIgnoreSpec.from_lines(patterns)
+
+
+@lru_cache(maxsize=None)
+def _compile_airflowignore_regex(pattern: str) -> re.Pattern[str]:
+    """Compile an airflowignore regexp pattern."""
+    return re.compile(pattern)
+
+
+def _matches_airflowignore_patterns(path: str, patterns: List[str]) -> Optional[bool]:
+    """Return the last matching gitignore-style decision for a scoped relative path."""
+    spec = _compile_airflowignore_spec(tuple(patterns))
+    include, _index = GitIgnoreSpec._match_file(enumerate(spec.patterns), path)
+    return include
+
+
+def _matches_airflowignore_regex(path: str, patterns: List[str]) -> bool:
+    """Return whether any regexp pattern matches the DAG-root-relative path."""
+    for pattern in patterns:
+        try:
+            if _compile_airflowignore_regex(pattern).search(path) is not None:
+                return True
+        except re.error as exc:
+            logging.warning("Ignoring invalid regex '%s' from .airflowignore: %s", pattern, exc)
+    return False
+
+
+def _should_ignore_file(file_path: Path, dags_folder: Path, ignore_patterns_by_dir: Dict[Path, List[str]]) -> bool:
     """
     Checks if a file should be ignored based on ignore patterns.
 
-    Patterns are matched against both the filename and the relative path from dags_folder.
+    Patterns use gitignore/Airflow-style gitwildmatch semantics, including directory
+    patterns ending in `/` and negation via `!`. Each .airflowignore applies relative
+    to the directory that contains it, and nested .airflowignore files are evaluated
+    from the DAG root down to the file's parent so later matches can override earlier ones.
+
     This allows for flexible matching, e.g.:
     - "test_*.yml" matches any file starting with "test_" and ending with ".yml"
     - "subdir/*.yaml" matches any .yaml file in the subdir directory
@@ -320,53 +412,81 @@ def _should_ignore_file(file_path: Path, dags_folder: Path, ignore_patterns: Lis
     :type file_path: Path
     :param dags_folder: Path to the DAGs folder (base directory)
     :type dags_folder: Path
-    :param ignore_patterns: List of ignore patterns to match against
-    :type ignore_patterns: List[str]
+    :param ignore_patterns_by_dir: Mapping of directory paths to ignore patterns
+    :type ignore_patterns_by_dir: Dict[Path, List[str]]
     :returns: True if the file should be ignored, False otherwise
     :rtype: bool
     """
-    if not ignore_patterns:
+    return _should_ignore_path(file_path, dags_folder, ignore_patterns_by_dir)
+
+
+
+def _should_ignore_path(path: Path, dags_folder: Path, ignore_patterns_by_dir: Dict[Path, List[str]]) -> bool:
+    """Checks if a file or directory should be ignored based on ignore patterns."""
+    if not ignore_patterns_by_dir:
         return False
 
+    ignore_file_syntax = _get_dag_ignore_file_syntax()
+
     try:
-        relative_path = file_path.resolve().relative_to(dags_folder.resolve())
-        relative_path_str = str(relative_path).replace("\\", "/")
-    except (ValueError, OSError):
-        # File is outside dags_folder or path resolution failed, only match by filename
+        relative_path_str = _lexical_relative_path(path, dags_folder)
+    except ValueError:
+        # Files outside dags_folder only match root-level basename patterns without path separators.
         relative_path_str = ""
 
-    filename = file_path.name
+    if ignore_file_syntax == "regexp":
+        if not relative_path_str:
+            return False
 
-    def _matches_pattern(pattern: str, filename: str, relative_path_str: str) -> bool:
-        """Checks if a pattern matches the given filename and/or relative path."""
-        if "**" in pattern:
-            prefix, suffix = pattern.split("**", 1)
-            prefix = prefix.rstrip("/")
-            suffix = suffix.lstrip("/")
+        scoped_patterns: List[str] = []
+        path_parts = Path(relative_path_str).parts
+        ancestor_dirs = [dags_folder]
+        for index in range(1, len(path_parts)):
+            ancestor_dirs.append(dags_folder / Path(*path_parts[:index]))
 
-            if not relative_path_str:
-                # File is outside dags_folder, only match by filename suffix
-                return bool(suffix and fnmatch.fnmatch(filename, suffix))
+        for ignore_dir in ancestor_dirs:
+            patterns = ignore_patterns_by_dir.get(ignore_dir)
+            if patterns:
+                scoped_patterns.extend(patterns)
 
-            if prefix and not relative_path_str.startswith(prefix):
-                return False
+        if path.is_dir():
+            relative_path_str = f"{relative_path_str}/"
 
-            remaining_path = relative_path_str[len(prefix) :].lstrip("/") if prefix else relative_path_str
+        return _matches_airflowignore_regex(relative_path_str, scoped_patterns)
 
-            if suffix:
-                return fnmatch.fnmatch(remaining_path, suffix) or fnmatch.fnmatch(filename, suffix)
-            else:
-                return True
-        else:
-            return fnmatch.fnmatch(filename, pattern) or (
-                relative_path_str and fnmatch.fnmatch(relative_path_str, pattern)
-            )
+    if ignore_file_syntax not in {"", "glob"}:
+        raise ValueError(f"Unsupported ignore_file_syntax: {ignore_file_syntax}")
 
-    for pattern in ignore_patterns:
-        if _matches_pattern(pattern, filename, relative_path_str):
-            return True
+    ignored = False
 
-    return False
+    if relative_path_str:
+        path_parts = Path(relative_path_str).parts
+        ancestor_dirs = [dags_folder]
+        for index in range(1, len(path_parts)):
+            ancestor_dirs.append(dags_folder / Path(*path_parts[:index]))
+
+        for ignore_dir in ancestor_dirs:
+            patterns = ignore_patterns_by_dir.get(ignore_dir)
+            if not patterns:
+                continue
+
+            scoped_relative_path = _lexical_relative_path(path, ignore_dir)
+            if path.is_dir():
+                scoped_relative_path = f"{scoped_relative_path}/"
+
+            match = _matches_airflowignore_patterns(scoped_relative_path, patterns)
+            if match is not None:
+                ignored = match
+
+        return ignored
+
+    root_patterns = ignore_patterns_by_dir.get(dags_folder, [])
+    if root_patterns:
+        match = _matches_airflowignore_patterns(path.name, root_patterns)
+        if match is not None:
+            ignored = match
+
+    return ignored
 
 
 def load_yaml_dags(
@@ -399,17 +519,27 @@ def load_yaml_dags(
     candidate_dag_files = []
 
     if config_filepath:
-        factory = _DagFactory(config_filepath=config_filepath, defaults_config_path=defaults_config_path)
+        factory = _DagFactory(
+            config_filepath=config_filepath,
+            defaults_config_path=defaults_config_path,
+            defaults_config_dict=defaults_config_dict,
+        )
         factory._generate_dags(globals_dict)
     elif config_dict:
-        factory = _DagFactory(config_dict=config_dict, defaults_config_dict=defaults_config_dict)
+        factory = _DagFactory(
+            config_dict=config_dict,
+            defaults_config_path=defaults_config_path,
+            defaults_config_dict=defaults_config_dict,
+        )
         factory._generate_dags(globals_dict)
     else:
         dags_folder_path = Path(dags_folder)
         ignore_patterns = _load_airflowignore(dags_folder)
 
-        for suf in suffix:
-            candidate_dag_files = list(chain(candidate_dag_files, dags_folder_path.rglob(f"*{suf}")))
+        for root_path, _dirs, files in _iter_dags_folder_contents(dags_folder_path):
+            for file_name in files:
+                if any(file_name.endswith(suf) for suf in suffix):
+                    candidate_dag_files.append(root_path / file_name)
 
         for config_file_path in candidate_dag_files:
             if _should_ignore_file(config_file_path, dags_folder_path, ignore_patterns):
@@ -419,7 +549,11 @@ def load_yaml_dags(
             config_file_abs_path = str(config_file_path.absolute())
             logging.info("Loading %s", config_file_abs_path)
             try:
-                factory = _DagFactory(config_file_abs_path, defaults_config_dict=defaults_config_dict)
+                factory = _DagFactory(
+                    config_file_abs_path,
+                    defaults_config_path=defaults_config_path,
+                    defaults_config_dict=defaults_config_dict,
+                )
                 factory._generate_dags(globals_dict)
             except Exception:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)

--- a/docs/configuration/load_yaml_dags.md
+++ b/docs/configuration/load_yaml_dags.md
@@ -1,6 +1,6 @@
 # load_yaml_dags Function
 
-The `load_yaml_dags` function is responsible for loading DAG configurations from YAML or YML files in a specified folder (or from a specific YAML file or dictionary). It parses the files or dictionary and generates Airflow DAGs by utilizing the provided globals_dict.
+The `load_yaml_dags` function loads DAG configurations from YAML/YML files in a folder, from a specific YAML file, or from a Python dictionary. It parses the config and generates Airflow DAGs with the provided `globals_dict`.
 
 ## Example Usage
 
@@ -9,8 +9,8 @@ The `load_yaml_dags` function is responsible for loading DAG configurations from
 ```python
 from dagfactory import load_yaml_dags
 
-# Load DAGs from a folder, e.g., /path/to/dags
-load_yaml_dags(globals_dict=globals(), dags_folder='/path/to/your/dags')
+# Load DAGs from a folder, e.g. /path/to/dags
+load_yaml_dags(globals_dict=globals(), dags_folder="/path/to/your/dags")
 ```
 
 ### 2. Loading from a Specific YAML File
@@ -18,37 +18,39 @@ load_yaml_dags(globals_dict=globals(), dags_folder='/path/to/your/dags')
 ```python
 from dagfactory import load_yaml_dags
 
-# Load DAG from a specific YAML file
-load_yaml_dags(globals_dict=globals(), config_filepath='/path/to/your/dag_config.yaml')
-
+# Load DAGs from a specific YAML file
+load_yaml_dags(globals_dict=globals(), config_filepath="/path/to/your/dag_config.yaml")
 ```
 
-### 3. Loading from YAML File with defaults_config_path
+### 3. Loading from a YAML File with `defaults_config_path`
 
 ```python
 from dagfactory import load_yaml_dags
 
-# Load a single DAG from a YAML file with custom default arguments config path
+# Load a single DAG from a YAML file with a custom defaults root directory
 load_yaml_dags(
     globals_dict=globals(),
-    config_filepath='/path/to/your/dag_config.yaml',
-    defaults_config_path='/path/to/your/defaults.yml'
+    config_filepath="/path/to/your/dag_config.yaml",
+    defaults_config_path="/path/to/your/config-root",
 )
 ```
+
+`defaults_config_path` should point to a directory root that contains one or more
+`defaults.yml` or `defaults.yaml` files, not to an individual defaults file.
 
 ### 4. Loading from a Dictionary
 
 ```python
 from dagfactory import load_yaml_dags
 
-# Load DAG from a dictionary configuration
+# Load DAGs from a dictionary configuration
 dag_config_dict = {
     # Your DAG configuration here
 }
 load_yaml_dags(globals_dict=globals(), config_dict=dag_config_dict)
 ```
 
-### 5. Loading from a Dictionary with default_args_config_dict
+### 5. Loading from a Dictionary with `defaults_config_dict`
 
 ```python
 from dagfactory import load_yaml_dags
@@ -59,7 +61,61 @@ default_args_dict = {
 }
 
 dag_config_dict = {
-     # Your DAG configuration here
+    # Your DAG configuration here
 }
-load_yaml_dags(globals_dict=globals(), config_dict=dag_config_dict, default_args_config_dict=default_args_dict)
+load_yaml_dags(
+    globals_dict=globals(),
+    config_dict=dag_config_dict,
+    defaults_config_dict=default_args_dict,
+)
 ```
+
+## `.airflowignore` Support
+
+When `load_yaml_dags` scans a `dags_folder`, it reads `.airflowignore` files in that folder tree and skips matching YAML files.
+
+- Matching syntax follows Airflow's `core.dag_ignore_file_syntax` setting.
+- In `glob` mode, patterns use gitignore-style `gitwildmatch` semantics, matching Airflow more closely.
+- In `regexp` mode, each non-comment line is treated as a regular expression matched against the DAG-root-relative path.
+- Empty lines are ignored.
+- `#` starts a comment for the rest of the line, so inline comments are stripped before matching.
+- In `glob` mode, patterns without `/` match matching basenames anywhere in the scoped subtree, not just at the root.
+- In `glob` mode, patterns ending in `/` ignore matching directories and everything beneath them.
+- In `glob` mode, negation patterns beginning with `!` re-include matching files, with later matches overriding earlier ones.
+- In `glob` mode, patterns with `/` are matched against the POSIX-style path relative to the directory that contains the matching `.airflowignore`.
+- Nested `.airflowignore` files apply to files in their own directory subtree and can override parent rules, unless a parent rule already prunes that subtree from traversal.
+- Symlinked directories are traversed for both YAML discovery and nested `.airflowignore` lookup.
+- Lexically in-tree symlinked files still participate in path-based matching.
+- For files outside `dags_folder`, only root-level basename patterns are considered in `glob` mode; scoped path rules do not apply.
+
+### Example `.airflowignore`
+
+```text
+*.yml
+!keep.yml
+ignored/
+backup/**/*.yaml
+```
+
+With this file:
+
+- `nested/test_example.yml` is ignored because basename patterns apply throughout the subtree.
+- `keep.yml` is **not** ignored because `!keep.yml` overrides the earlier `*.yml` match.
+- `ignored/dag.yml` is ignored.
+- `nested/ignored/dag.yml` is also ignored by `ignored/`.
+- `backup/file.yaml` is ignored.
+- `backup/subdir/file.yaml` is ignored.
+- `backup2/file.yaml` is **not** ignored by `backup/**/*.yaml`.
+
+### Example
+
+```python
+from dagfactory import load_yaml_dags
+
+load_yaml_dags(
+    globals_dict=globals(),
+    dags_folder="/path/to/your/dags",
+)
+```
+
+If `/path/to/your/dags/.airflowignore` exists, matching YAML files are skipped during discovery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.9",
+    "pathspec",
     "pyyaml",
     "packaging",
     "typer"

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -39,8 +39,7 @@ elif [ "$AIRFLOW_VERSION" = "3.1" ]; then
 elif [ "$AIRFLOW_VERSION" = "3.2" ]; then
   uv pip install "apache-airflow~=3.2.0" "apache-airflow-providers-http>=4.0.0"  "apache-airflow-providers-cncf-kubernetes>=4.4.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack" --constraint /tmp/constraint.txt
 else
-  uv pip install "apache-airflow==$AIRFLOW_VERSION"  "apache-airflow-providers-http>=4.0.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack"  --constraint /tmp/constraint.txt
-  pip install  "apache-airflow==$AIRFLOW_VERSION"  "apache-airflow-providers-cncf-kubernetes>=4.4.0"
+  uv pip install "apache-airflow==$AIRFLOW_VERSION" "apache-airflow-providers-http>=4.0.0" "apache-airflow-providers-cncf-kubernetes>=4.4.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack" --constraint /tmp/constraint.txt
 fi;
 
 rm /tmp/constraint.txt

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -764,8 +764,9 @@ def test_load_airflowignore_read_failure(caplog, tmp_path):
         ),
     ],
 )
-def test_should_ignore_file(tmp_path, file_path_str, ignore_patterns, expected, outside_dags_folder):
+def test_should_ignore_file(monkeypatch, tmp_path, file_path_str, ignore_patterns, expected, outside_dags_folder):
     """Test that _should_ignore_file matches patterns correctly."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     dags_folder = tmp_path
     ignore_patterns_by_dir = {dags_folder / relative_dir: patterns for relative_dir, patterns in ignore_patterns.items()}
 
@@ -779,8 +780,9 @@ def test_should_ignore_file(tmp_path, file_path_str, ignore_patterns, expected, 
     assert _should_ignore_file(file_path, dags_folder, ignore_patterns_by_dir) is expected
 
 
-def test_should_ignore_file_uses_lexical_path_for_symlinked_files(tmp_path):
+def test_should_ignore_file_uses_lexical_path_for_symlinked_files(monkeypatch, tmp_path):
     """Lexically in-tree symlinked files should still match path-based ignore patterns."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     dags_folder = tmp_path
     external_target = tmp_path.parent / "external_dag.yml"
     external_target.write_text("external")
@@ -854,8 +856,9 @@ default:
     )
 
 
-def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
+def test_load_yaml_dags_with_airflowignore(monkeypatch, caplog, tmp_path):
     """Test that load_yaml_dags respects .airflowignore file."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -878,8 +881,9 @@ def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
     assert any("Ignoring file" in msg and "test_ignored.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_with_nested_airflowignore(caplog, tmp_path):
+def test_load_yaml_dags_with_nested_airflowignore(monkeypatch, caplog, tmp_path):
     """Nested .airflowignore files should apply relative to their own directory."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -901,8 +905,9 @@ def test_load_yaml_dags_with_nested_airflowignore(caplog, tmp_path):
     assert any("Ignoring file" in msg and "nested/ignored/skip.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_with_symlinked_file_uses_lexical_path_ignore(caplog, tmp_path):
+def test_load_yaml_dags_with_symlinked_file_uses_lexical_path_ignore(monkeypatch, caplog, tmp_path):
     """Path-based ignore patterns should still match lexically in-tree symlinked files."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -922,8 +927,9 @@ def test_load_yaml_dags_with_symlinked_file_uses_lexical_path_ignore(caplog, tmp
     assert any("Ignoring file" in msg and "symlinked/external_dag.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_follows_symlinked_directories_and_nested_airflowignore(caplog, tmp_path):
+def test_load_yaml_dags_follows_symlinked_directories_and_nested_airflowignore(monkeypatch, caplog, tmp_path):
     """Symlinked directories should be scanned and use their nested .airflowignore rules."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -944,8 +950,9 @@ def test_load_yaml_dags_follows_symlinked_directories_and_nested_airflowignore(c
     assert any("Ignoring file" in msg and "linked/ignored/skip.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_with_airflowignore_negation(caplog, tmp_path):
+def test_load_yaml_dags_with_airflowignore_negation(monkeypatch, caplog, tmp_path):
     """Negated patterns should re-include matching files within the same ignore scope."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -962,8 +969,9 @@ def test_load_yaml_dags_with_airflowignore_negation(caplog, tmp_path):
     assert any("Ignoring file" in msg and "skip.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_with_nested_airflowignore_negation(caplog, tmp_path):
+def test_load_yaml_dags_with_nested_airflowignore_negation(monkeypatch, caplog, tmp_path):
     """Nested negations should override parent ignore rules for files in that subtree."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -1007,8 +1015,9 @@ def test_load_yaml_dags_prunes_parent_ignored_subtrees(monkeypatch, caplog, tmp_
     assert not any("Loading" in msg and "ignored/keep.yml" in msg for msg in caplog.messages)
 
 
-def test_load_yaml_dags_with_directory_airflowignore_pattern(caplog, tmp_path):
+def test_load_yaml_dags_with_directory_airflowignore_pattern(monkeypatch, caplog, tmp_path):
     """Directory patterns ending with `/` should ignore matching subtrees."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -1085,9 +1094,10 @@ def test_load_yaml_dags_with_airflowignore_regexp_syntax(monkeypatch, caplog, tm
     ],
 )
 def test_load_yaml_dags_with_airflowignore_scenarios(
-    tmp_path, dag_files, ignore_patterns, expected_loaded, expected_not_loaded
+    monkeypatch, tmp_path, dag_files, ignore_patterns, expected_loaded, expected_not_loaded
 ):
     """Test various .airflowignore scenarios"""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     bash_operator_path = get_bash_operator_path()
 
     # Create DAG files

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -24,7 +24,7 @@ from tests.utils import get_bash_operator_path
 here = os.path.dirname(__file__)
 
 from dagfactory import dagfactory, load_yaml_dags
-from dagfactory.dagfactory import _DagFactory, _load_airflowignore, _should_ignore_file
+from dagfactory.dagfactory import _DagFactory, _get_dag_ignore_file_syntax, _load_airflowignore, _should_ignore_file
 
 TEST_DAG_FACTORY = os.path.join(here, "fixtures/dag_factory.yml")
 DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE = os.path.join(here, "fixtures/dag_factory_no_or_none_string_schedule.yml")
@@ -537,6 +537,51 @@ def test_build_dag_with_global_default():
     assert dags.get("example_dag").tasks[0].depends_on_past == True
 
 
+def test_load_yaml_dags_folder_scan_forwards_defaults_config_path(tmp_path):
+    defaults_root = tmp_path / "defaults_root"
+    dags_folder = defaults_root / "nested"
+    dags_folder.mkdir(parents=True)
+
+    dag_file = dags_folder / "dag.yml"
+    shutil.copyfile(DAG_FACTORY_VARIABLES_AS_ARGUMENTS, dag_file)
+
+    with open(defaults_root / "defaults.yml", "w") as fp:
+        yaml.dump({"default_args": {"depends_on_past": True}}, fp)
+
+    globals_dict = {}
+    load_yaml_dags(
+        globals_dict=globals_dict,
+        dags_folder=str(dags_folder),
+        defaults_config_path=str(defaults_root),
+    )
+
+    assert globals_dict["example_dag"].tasks[0].depends_on_past == True
+
+
+def test_load_yaml_dags_config_dict_forwards_defaults_config_path():
+    globals_dict = {}
+
+    load_yaml_dags(
+        globals_dict=globals_dict,
+        config_dict=DAG_FACTORY_CONFIG,
+        defaults_config_path=DEFAULT_ARGS_CONFIG_ROOT,
+    )
+
+    assert globals_dict["example_dag"].tasks[0].depends_on_past == True
+
+
+def test_load_yaml_dags_config_filepath_forwards_defaults_config_dict():
+    globals_dict = {}
+
+    load_yaml_dags(
+        globals_dict=globals_dict,
+        config_filepath=DAG_FACTORY_VARIABLES_AS_ARGUMENTS,
+        defaults_config_dict={"default_args": {"depends_on_past": True}},
+    )
+
+    assert globals_dict["example_dag"].tasks[0].depends_on_past == True
+
+
 def test_build_dag_with_global_dag_level_defaults():
     """Test that DAG-level defaults from global defaults.yml are applied to individual DAG configs"""
     global_defaults = {
@@ -601,38 +646,70 @@ def test_load_yaml_dags_default_suffix_succeed(caplog):
 
 
 @pytest.mark.parametrize(
-    "ignore_file_content,expected_patterns",
+    "root_ignore_file_content,nested_ignore_file_content,expected_patterns",
     [
-        (None, []),  # File doesn't exist
-        ("", []),  # Empty file
+        (None, None, {}),  # No ignore files
+        ("", None, {Path("."): []}),  # Empty file
         (
             "test_*.yml\n*_test.yaml\n# This is a comment\nold_dags/*.yaml\nbackup/**/*.yml\n",
-            ["test_*.yml", "*_test.yaml", "old_dags/*.yaml", "backup/**/*.yml"],
+            None,
+            {Path("."): ["test_*.yml", "*_test.yaml", "old_dags/*.yaml", "backup/**/*.yml"]},
         ),
-        ("  test_*.yml  \n    \n*_test.yaml\n", ["test_*.yml", "*_test.yaml"]),
+        (
+            "  test_*.yml  \n    \n*_test.yaml\n",
+            "nested/*.yml\n",
+            {Path("."): ["test_*.yml", "*_test.yaml"], Path("subdir"): ["nested/*.yml"]},
+        ),
+        (
+            "test_*.yml # inline comment\n*_test.yaml  # another comment\n",
+            None,
+            {Path("."): ["test_*.yml", "*_test.yaml"]},
+        ),
     ],
 )
-def test_load_airflowignore(tmp_path, ignore_file_content, expected_patterns):
-    """Test that _load_airflowignore loads patterns correctly"""
-    if ignore_file_content is not None:
-        ignore_file = tmp_path / ".airflowignore"
-        ignore_file.write_text(ignore_file_content)
+def test_load_airflowignore(tmp_path, root_ignore_file_content, nested_ignore_file_content, expected_patterns):
+    """Test that _load_airflowignore loads root and nested patterns correctly."""
+    if root_ignore_file_content is not None:
+        (tmp_path / ".airflowignore").write_text(root_ignore_file_content)
+
+    if nested_ignore_file_content is not None:
+        nested_dir = tmp_path / "subdir"
+        nested_dir.mkdir()
+        (nested_dir / ".airflowignore").write_text(nested_ignore_file_content)
 
     ignore_patterns = _load_airflowignore(str(tmp_path))
-    assert ignore_patterns == expected_patterns
-    assert "# This is a comment" not in ignore_patterns if ignore_file_content else True
+    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+    assert relative_ignore_patterns == expected_patterns
+
+    loaded_patterns = [pattern for patterns in ignore_patterns.values() for pattern in patterns]
+    assert "# This is a comment" not in loaded_patterns
+
+
+def test_load_airflowignore_follows_symlinked_directories(tmp_path):
+    """Nested .airflowignore files inside symlinked directories should be discovered."""
+    external_dir = tmp_path.parent / "airflowignore_external"
+    external_dir.mkdir()
+    (external_dir / ".airflowignore").write_text("ignored/*.yml\n")
+
+    symlink_dir = tmp_path / "linked"
+    symlink_dir.symlink_to(external_dir, target_is_directory=True)
+
+    ignore_patterns = _load_airflowignore(str(tmp_path))
+    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+
+    assert relative_ignore_patterns == {Path("linked"): ["ignored/*.yml"]}
 
 
 def test_load_airflowignore_read_failure(caplog, tmp_path):
-    """Test that _load_airflowignore handles file read failures gracefully"""
+    """Test that _load_airflowignore handles file read failures gracefully."""
     caplog.set_level(logging.WARNING)
     ignore_file = tmp_path / ".airflowignore"
     ignore_file.write_text("test_*.yml\n")
 
     # Mock open to raise OSError
-    with patch("dagfactory.dagfactory.open", side_effect=OSError("Permission denied")):
+    with patch("builtins.open", side_effect=OSError("Permission denied")):
         ignore_patterns = _load_airflowignore(str(tmp_path))
-        assert ignore_patterns == []
+        assert ignore_patterns == {tmp_path: []}
         assert any("Failed to read .airflowignore" in msg for msg in caplog.messages)
 
 
@@ -640,41 +717,127 @@ def test_load_airflowignore_read_failure(caplog, tmp_path):
     "file_path_str,ignore_patterns,expected,outside_dags_folder",
     [
         # Basic patterns
-        ("test.yml", [], False, False),
-        ("test_example.yml", ["test_*.yml"], True, False),
-        ("old_dags/dag.yml", ["old_dags/*.yml"], True, False),
-        ("valid_dag.yml", ["test_*.yml", "old_dags/*.yaml"], False, False),
+        ("test.yml", {}, False, False),
+        ("test_example.yml", {Path("."): ["test_*.yml"]}, True, False),
+        ("nested/test_example.yml", {Path("."): ["test_*.yml"]}, True, False),
+        ("old_dags/dag.yml", {Path("."): ["old_dags/*.yml"]}, True, False),
+        ("old_dags/sub/inner.yml", {Path("."): ["old_dags/*.yml"]}, False, False),
+        ("valid_dag.yml", {Path("."): ["test_*.yml", "old_dags/*.yaml"]}, False, False),
+        # Directory and negation patterns
+        ("ignored/file.yml", {Path("."): ["ignored/"]}, True, False),
+        ("nested/ignored/file.yml", {Path("."): ["ignored/"]}, True, False),
+        ("keep.yml", {Path("."): ["*.yml", "!keep.yml"]}, False, False),
+        ("nested/keep.yml", {Path("."): ["*.yml", "!keep.yml"]}, False, False),
+        ("nested/skip.yml", {Path("."): ["*.yml", "!keep.yml"]}, True, False),
         # Recursive patterns
-        ("backup/backup_dag.yaml", ["backup/**/*.yaml"], True, False),
-        ("backup/subdir/file.yaml", ["backup/**/*.yaml"], True, False),
+        ("backup/backup_dag.yaml", {Path("."): ["backup/**/*.yaml"]}, True, False),
+        ("backup/file.yaml", {Path("."): ["backup/**/*.yaml"]}, True, False),
+        ("backup/subdir/file.yaml", {Path("."): ["backup/**/*.yaml"]}, True, False),
+        ("backup/subdir/nested/file.yaml", {Path("."): ["backup/**/*.yaml"]}, True, False),
+        ("backup2/file.yaml", {Path("."): ["backup/**/*.yaml"]}, False, False),
+        ("backup_file.yaml", {Path("."): ["backup/**/*.yaml"]}, False, False),
         # Recursive pattern without suffix
-        ("backup/file1.yaml", ["backup/**"], True, False),
-        ("backup/subdir/file2.yaml", ["backup/**"], True, False),
-        ("backup/subdir/nested/file3.yaml", ["backup/**"], True, False),
-        ("other_file.yaml", ["backup/**"], False, False),
+        ("backup/file1.yaml", {Path("."): ["backup/**"]}, True, False),
+        ("backup/subdir/file2.yaml", {Path("."): ["backup/**"]}, True, False),
+        ("backup/subdir/nested/file3.yaml", {Path("."): ["backup/**"]}, True, False),
+        ("backup2/file.yaml", {Path("."): ["backup/**"]}, False, False),
+        ("backup_file.yaml", {Path("."): ["backup/**"]}, False, False),
+        ("other_file.yaml", {Path("."): ["backup/**"]}, False, False),
         # Files outside dags_folder
-        ("outside_file.yml", ["outside_*.yml"], True, True),
-        ("outside_file.yml", ["test_*.yml"], False, True),
-        ("backup_file.yaml", ["backup/**/*.yaml"], True, True),
-        ("backup_file.yaml", ["backup/**/*.yml"], False, True),
+        ("outside_file.yml", {Path("."): ["outside_*.yml"]}, True, True),
+        ("outside_file.yml", {Path("."): ["test_*.yml"]}, False, True),
+        ("backup_file.yaml", {Path("."): ["backup/**/*.yaml"]}, False, True),
+        ("backup_file.yaml", {Path("."): ["backup/**/*.yml"]}, False, True),
+        ("file.yaml", {Path("."): ["backup/**/*.yaml"]}, False, True),
+        # Nested .airflowignore files are applied relative to their own directory
+        (
+            "nested/ignored/child.yml",
+            {Path("nested"): ["ignored/*.yml"]},
+            True,
+            False,
+        ),
+        (
+            "nested/other/child.yml",
+            {Path("nested"): ["ignored/*.yml"]},
+            False,
+            False,
+        ),
     ],
 )
 def test_should_ignore_file(tmp_path, file_path_str, ignore_patterns, expected, outside_dags_folder):
-    """Test that _should_ignore_file matches patterns correctly"""
+    """Test that _should_ignore_file matches patterns correctly."""
+    dags_folder = tmp_path
+    ignore_patterns_by_dir = {dags_folder / relative_dir: patterns for relative_dir, patterns in ignore_patterns.items()}
+
     if outside_dags_folder:
         file_path = tmp_path.parent / file_path_str
-        dags_folder = tmp_path
     else:
         file_path = tmp_path / file_path_str
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        dags_folder = tmp_path
 
     file_path.touch()
-    assert _should_ignore_file(file_path, dags_folder, ignore_patterns) is expected
+    assert _should_ignore_file(file_path, dags_folder, ignore_patterns_by_dir) is expected
+
+
+def test_should_ignore_file_uses_lexical_path_for_symlinked_files(tmp_path):
+    """Lexically in-tree symlinked files should still match path-based ignore patterns."""
+    dags_folder = tmp_path
+    external_target = tmp_path.parent / "external_dag.yml"
+    external_target.write_text("external")
+
+    symlink_path = dags_folder / "symlinked" / "external_dag.yml"
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+    symlink_path.symlink_to(external_target)
+
+    ignore_patterns = {dags_folder: ["symlinked/*.yml"]}
+    assert _should_ignore_file(symlink_path, dags_folder, ignore_patterns) is True
+
+
+def test_get_dag_ignore_file_syntax_defaults_to_glob(monkeypatch):
+    monkeypatch.setattr(dagfactory.airflow_conf, "get", lambda *args, **kwargs: kwargs.get("fallback", "glob"))
+
+    assert _get_dag_ignore_file_syntax() == "glob"
+
+
+def test_should_ignore_file_respects_regexp_syntax(monkeypatch, tmp_path):
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "regexp")
+
+    dags_folder = tmp_path
+    ignore_patterns = {
+        dags_folder: [r"(^|/)skip_.*\.ya?ml$"],
+        dags_folder / "nested": [r"^nested/also_skip\.ya?ml$"],
+    }
+
+    skip_root = dags_folder / "skip_root.yml"
+    keep_root = dags_folder / "keep_root.yml"
+    skip_nested = dags_folder / "nested" / "skip_nested.yaml"
+    also_skip_nested = dags_folder / "nested" / "also_skip.yml"
+    keep_nested = dags_folder / "nested" / "keep_nested.yml"
+
+    for file_path in [skip_root, keep_root, skip_nested, also_skip_nested, keep_nested]:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+    assert _should_ignore_file(skip_root, dags_folder, ignore_patterns) is True
+    assert _should_ignore_file(keep_root, dags_folder, ignore_patterns) is False
+    assert _should_ignore_file(skip_nested, dags_folder, ignore_patterns) is True
+    assert _should_ignore_file(also_skip_nested, dags_folder, ignore_patterns) is True
+    assert _should_ignore_file(keep_nested, dags_folder, ignore_patterns) is False
+
+
+def test_should_ignore_file_regexp_ignores_outside_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "regexp")
+
+    dags_folder = tmp_path
+    outside_file = tmp_path.parent / "skip_outside.yml"
+    outside_file.touch()
+
+    assert _should_ignore_file(outside_file, dags_folder, {dags_folder: [r"skip_.*\.yml$"]}) is False
 
 
 def _create_dag_file(file_path: Path, dag_id: str, bash_operator_path: str) -> None:
     """Helper function to create a DAG YAML file"""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(
         f"""
 default:
@@ -692,7 +855,7 @@ default:
 
 
 def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
-    """Test that load_yaml_dags respects .airflowignore file"""
+    """Test that load_yaml_dags respects .airflowignore file."""
     caplog.set_level(logging.DEBUG)
     bash_operator_path = get_bash_operator_path()
 
@@ -715,6 +878,179 @@ def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
     assert any("Ignoring file" in msg and "test_ignored.yml" in msg for msg in caplog.messages)
 
 
+def test_load_yaml_dags_with_nested_airflowignore(caplog, tmp_path):
+    """Nested .airflowignore files should apply relative to their own directory."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "valid_dag.yml", "valid_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "kept.yml", "nested_kept_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "ignored" / "skip.yml", "nested_ignored_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "other" / "keep.yml", "nested_other_kept_dag", bash_operator_path)
+
+    (tmp_path / "nested").mkdir(exist_ok=True)
+    (tmp_path / "nested" / ".airflowignore").write_text("ignored/*.yml\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "valid_dag" in globals_dict
+    assert "nested_kept_dag" in globals_dict
+    assert "nested_other_kept_dag" in globals_dict
+    assert "nested_ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "nested/ignored/skip.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_with_symlinked_file_uses_lexical_path_ignore(caplog, tmp_path):
+    """Path-based ignore patterns should still match lexically in-tree symlinked files."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    external_target = tmp_path.parent / "external_dag.yml"
+    _create_dag_file(external_target, "symlinked_ignored_dag", bash_operator_path)
+
+    symlink_path = tmp_path / "symlinked" / "external_dag.yml"
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+    symlink_path.symlink_to(external_target)
+
+    (tmp_path / ".airflowignore").write_text("symlinked/*.yml\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "symlinked_ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "symlinked/external_dag.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_follows_symlinked_directories_and_nested_airflowignore(caplog, tmp_path):
+    """Symlinked directories should be scanned and use their nested .airflowignore rules."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    external_dir = tmp_path.parent / "symlinked_dags_external"
+    external_dir.mkdir()
+    _create_dag_file(external_dir / "ignored" / "skip.yml", "symlinked_nested_ignored_dag", bash_operator_path)
+    _create_dag_file(external_dir / "keep.yml", "symlinked_nested_kept_dag", bash_operator_path)
+    (external_dir / ".airflowignore").write_text("ignored/*.yml\n")
+
+    symlink_dir = tmp_path / "linked"
+    symlink_dir.symlink_to(external_dir, target_is_directory=True)
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "symlinked_nested_kept_dag" in globals_dict
+    assert "symlinked_nested_ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "linked/ignored/skip.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_with_airflowignore_negation(caplog, tmp_path):
+    """Negated patterns should re-include matching files within the same ignore scope."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "skip.yml", "ignored_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "keep.yml", "kept_dag", bash_operator_path)
+
+    (tmp_path / ".airflowignore").write_text("*.yml\n!keep.yml\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "kept_dag" in globals_dict
+    assert "ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "skip.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_with_nested_airflowignore_negation(caplog, tmp_path):
+    """Nested negations should override parent ignore rules for files in that subtree."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "nested" / "keep.yml", "nested_kept_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "skip.yml", "nested_ignored_dag", bash_operator_path)
+
+    (tmp_path / ".airflowignore").write_text("*.yml\n")
+    (tmp_path / "nested").mkdir(exist_ok=True)
+    (tmp_path / "nested" / ".airflowignore").write_text("!keep.yml\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "nested_kept_dag" in globals_dict
+    assert "nested_ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "nested/skip.yml" in msg for msg in caplog.messages)
+
+
+@pytest.mark.parametrize("ignore_syntax", ["glob", "regexp"])
+def test_load_yaml_dags_prunes_parent_ignored_subtrees(monkeypatch, caplog, tmp_path, ignore_syntax):
+    """Parent-ignored directories should not be traversed or load nested .airflowignore files."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: ignore_syntax)
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "kept.yml", "kept_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "ignored" / "keep.yml", "ignored_kept_dag", bash_operator_path)
+
+    (tmp_path / ".airflowignore").write_text("ignored/\n")
+    (tmp_path / "ignored" / ".airflowignore").write_text("!keep.yml\n")
+
+    ignore_patterns = _load_airflowignore(str(tmp_path))
+    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+    assert relative_ignore_patterns == {Path("."): ["ignored/"]}
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "kept_dag" in globals_dict
+    assert "ignored_kept_dag" not in globals_dict
+    assert not any("Loading" in msg and "ignored/keep.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_with_directory_airflowignore_pattern(caplog, tmp_path):
+    """Directory patterns ending with `/` should ignore matching subtrees."""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "ignored" / "skip.yml", "ignored_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "ignored" / "skip.yml", "nested_ignored_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "kept.yml", "kept_dag", bash_operator_path)
+
+    (tmp_path / ".airflowignore").write_text("ignored/\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "kept_dag" in globals_dict
+    assert "ignored_dag" not in globals_dict
+    assert "nested_ignored_dag" not in globals_dict
+    assert not any("Loading" in msg and "ignored/skip.yml" in msg for msg in caplog.messages)
+
+
+def test_load_yaml_dags_with_airflowignore_regexp_syntax(monkeypatch, caplog, tmp_path):
+    """Regexp syntax should follow Airflow's dag_ignore_file_syntax setting."""
+    monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "regexp")
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    _create_dag_file(tmp_path / "keep.yml", "kept_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "skip_root.yml", "ignored_root_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "skip_nested.yaml", "ignored_nested_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "nested" / "keep_nested.yml", "kept_nested_dag", bash_operator_path)
+
+    (tmp_path / ".airflowignore").write_text("(^|/)skip_.*\\.ya?ml$\n")
+
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    assert "kept_dag" in globals_dict
+    assert "kept_nested_dag" in globals_dict
+    assert "ignored_root_dag" not in globals_dict
+    assert "ignored_nested_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "skip_root.yml" in msg for msg in caplog.messages)
+    assert any("Ignoring file" in msg and "nested/skip_nested.yaml" in msg for msg in caplog.messages)
+
+
 @pytest.mark.parametrize(
     "dag_files,ignore_patterns,expected_loaded,expected_not_loaded",
     [
@@ -724,6 +1060,18 @@ def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
             "old_dags/*.yml\nbackup/**/*.yaml\n",
             ["valid_dag"],
             ["old_dag", "backup_dag"],
+        ),
+        # Path-aware matching should not ignore similarly named paths
+        (
+            {
+                "valid_dag.yml": "valid_dag",
+                "backup2/file.yaml": "backup2_dag",
+                "backup_file.yaml": "backup_file_dag",
+                "old_dags/sub/inner.yml": "old_dags_inner_dag",
+            },
+            "old_dags/*.yml\nbackup/**/*.yaml\n",
+            ["valid_dag", "backup2_dag", "backup_file_dag", "old_dags_inner_dag"],
+            [],
         ),
         # No ignore file
         ({"dag1.yml": "dag1", "dag2.yaml": "dag2"}, None, ["dag1", "dag2"], []),

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -24,7 +24,7 @@ from tests.utils import get_bash_operator_path
 here = os.path.dirname(__file__)
 
 from dagfactory import dagfactory, load_yaml_dags
-from dagfactory.dagfactory import _DagFactory
+from dagfactory.dagfactory import _DagFactory, _load_airflowignore, _should_ignore_file
 
 TEST_DAG_FACTORY = os.path.join(here, "fixtures/dag_factory.yml")
 DAG_FACTORY_NO_OR_NONE_STRING_SCHEDULE = os.path.join(here, "fixtures/dag_factory_no_or_none_string_schedule.yml")
@@ -598,6 +598,169 @@ def test_load_yaml_dags_default_suffix_succeed(caplog):
         dags_folder="tests/fixtures",
     )
     assert "Loading DAGs from tests/fixtures" in caplog.messages
+
+
+@pytest.mark.parametrize(
+    "ignore_file_content,expected_patterns",
+    [
+        (None, []),  # File doesn't exist
+        ("", []),  # Empty file
+        (
+            "test_*.yml\n*_test.yaml\n# This is a comment\nold_dags/*.yaml\nbackup/**/*.yml\n",
+            ["test_*.yml", "*_test.yaml", "old_dags/*.yaml", "backup/**/*.yml"],
+        ),
+        ("  test_*.yml  \n    \n*_test.yaml\n", ["test_*.yml", "*_test.yaml"]),
+    ],
+)
+def test_load_airflowignore(tmp_path, ignore_file_content, expected_patterns):
+    """Test that _load_airflowignore loads patterns correctly"""
+    if ignore_file_content is not None:
+        ignore_file = tmp_path / ".airflowignore"
+        ignore_file.write_text(ignore_file_content)
+
+    ignore_patterns = _load_airflowignore(str(tmp_path))
+    assert ignore_patterns == expected_patterns
+    assert "# This is a comment" not in ignore_patterns if ignore_file_content else True
+
+
+def test_load_airflowignore_read_failure(caplog, tmp_path):
+    """Test that _load_airflowignore handles file read failures gracefully"""
+    caplog.set_level(logging.WARNING)
+    ignore_file = tmp_path / ".airflowignore"
+    ignore_file.write_text("test_*.yml\n")
+
+    # Mock open to raise OSError
+    with patch("dagfactory.dagfactory.open", side_effect=OSError("Permission denied")):
+        ignore_patterns = _load_airflowignore(str(tmp_path))
+        assert ignore_patterns == []
+        assert any("Failed to read .airflowignore" in msg for msg in caplog.messages)
+
+
+@pytest.mark.parametrize(
+    "file_path_str,ignore_patterns,expected,outside_dags_folder",
+    [
+        # Basic patterns
+        ("test.yml", [], False, False),
+        ("test_example.yml", ["test_*.yml"], True, False),
+        ("old_dags/dag.yml", ["old_dags/*.yml"], True, False),
+        ("valid_dag.yml", ["test_*.yml", "old_dags/*.yaml"], False, False),
+        # Recursive patterns
+        ("backup/backup_dag.yaml", ["backup/**/*.yaml"], True, False),
+        ("backup/subdir/file.yaml", ["backup/**/*.yaml"], True, False),
+        # Recursive pattern without suffix
+        ("backup/file1.yaml", ["backup/**"], True, False),
+        ("backup/subdir/file2.yaml", ["backup/**"], True, False),
+        ("backup/subdir/nested/file3.yaml", ["backup/**"], True, False),
+        ("other_file.yaml", ["backup/**"], False, False),
+        # Files outside dags_folder
+        ("outside_file.yml", ["outside_*.yml"], True, True),
+        ("outside_file.yml", ["test_*.yml"], False, True),
+        ("backup_file.yaml", ["backup/**/*.yaml"], True, True),
+        ("backup_file.yaml", ["backup/**/*.yml"], False, True),
+    ],
+)
+def test_should_ignore_file(tmp_path, file_path_str, ignore_patterns, expected, outside_dags_folder):
+    """Test that _should_ignore_file matches patterns correctly"""
+    if outside_dags_folder:
+        file_path = tmp_path.parent / file_path_str
+        dags_folder = tmp_path
+    else:
+        file_path = tmp_path / file_path_str
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        dags_folder = tmp_path
+
+    file_path.touch()
+    assert _should_ignore_file(file_path, dags_folder, ignore_patterns) is expected
+
+
+def _create_dag_file(file_path: Path, dag_id: str, bash_operator_path: str) -> None:
+    """Helper function to create a DAG YAML file"""
+    file_path.write_text(
+        f"""
+default:
+  default_args:
+    owner: airflow
+    start_date: 2024-01-01
+{dag_id}:
+  schedule: "@daily"
+  tasks:
+    - task_id: task_1
+      operator: {bash_operator_path}
+      bash_command: echo 1
+"""
+    )
+
+
+def test_load_yaml_dags_with_airflowignore(caplog, tmp_path):
+    """Test that load_yaml_dags respects .airflowignore file"""
+    caplog.set_level(logging.DEBUG)
+    bash_operator_path = get_bash_operator_path()
+
+    # Create test DAG files
+    _create_dag_file(tmp_path / "valid_dag.yml", "valid_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "test_ignored.yml", "ignored_dag", bash_operator_path)
+    _create_dag_file(tmp_path / "another_valid.yaml", "another_valid_dag", bash_operator_path)
+
+    # Create .airflowignore file
+    (tmp_path / ".airflowignore").write_text("test_*.yml\n")
+
+    # Load DAGs
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    # Check results
+    assert "valid_dag" in globals_dict
+    assert "another_valid_dag" in globals_dict
+    assert "ignored_dag" not in globals_dict
+    assert any("Ignoring file" in msg and "test_ignored.yml" in msg for msg in caplog.messages)
+
+
+@pytest.mark.parametrize(
+    "dag_files,ignore_patterns,expected_loaded,expected_not_loaded",
+    [
+        # Subdirectory patterns
+        (
+            {"valid_dag.yml": "valid_dag", "old_dags/old_dag.yml": "old_dag", "backup/backup_dag.yaml": "backup_dag"},
+            "old_dags/*.yml\nbackup/**/*.yaml\n",
+            ["valid_dag"],
+            ["old_dag", "backup_dag"],
+        ),
+        # No ignore file
+        ({"dag1.yml": "dag1", "dag2.yaml": "dag2"}, None, ["dag1", "dag2"], []),
+        # Comments in ignore file
+        (
+            {"valid_dag.yml": "valid_dag", "test_dag.yml": "test_dag"},
+            "# This is a comment\n# Another comment\ntest_*.yml\n# Yet another comment\n",
+            ["valid_dag"],
+            ["test_dag"],
+        ),
+    ],
+)
+def test_load_yaml_dags_with_airflowignore_scenarios(
+    tmp_path, dag_files, ignore_patterns, expected_loaded, expected_not_loaded
+):
+    """Test various .airflowignore scenarios"""
+    bash_operator_path = get_bash_operator_path()
+
+    # Create DAG files
+    for file_path_str, dag_id in dag_files.items():
+        file_path = tmp_path / file_path_str
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        _create_dag_file(file_path, dag_id, bash_operator_path)
+
+    # Create .airflowignore file if provided
+    if ignore_patterns:
+        (tmp_path / ".airflowignore").write_text(ignore_patterns)
+
+    # Load DAGs
+    globals_dict = {}
+    load_yaml_dags(globals_dict=globals_dict, dags_folder=str(tmp_path))
+
+    # Check results
+    for dag_id in expected_loaded:
+        assert dag_id in globals_dict, f"Expected {dag_id} to be loaded"
+    for dag_id in expected_not_loaded:
+        assert dag_id not in globals_dict, f"Expected {dag_id} to be ignored"
 
 
 @pytest.mark.skipif(

--- a/uv.lock
+++ b/uv.lock
@@ -951,6 +951,7 @@ source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },
     { name = "packaging" },
+    { name = "pathspec" },
     { name = "pyyaml" },
     { name = "typer" },
 ]
@@ -1003,6 +1004,7 @@ requires-dist = [
     { name = "packaging" },
     { name = "packaging", marker = "extra == 'all'" },
     { name = "pandas", marker = "extra == 'tests'" },
+    { name = "pathspec" },
     { name = "pre-commit", marker = "extra == 'tests'" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=6.0" },
     { name = "pytest-cov", marker = "extra == 'tests'" },


### PR DESCRIPTION
This PR adds support for `.airflowignore` file in `load_yaml_dags()` function, allowing users to exclude specific YAML files from being loaded. This feature follows the same format as Airflow's `.airflowignore` file and supports glob-style pattern matching.

closes #527

## Changes

### New Features

- **`.airflowignore` file support**: `load_yaml_dags()` now automatically reads and respects `.airflowignore` files in the DAGs folder
- **Pattern matching**: Supports glob-style patterns including:
  - Filename patterns: `test_*.yml`, `*_test.yaml`
  - Directory patterns: `old_dags/*.yaml`, `backup/**/*.yml`
  - Recursive matching: `**` for matching files in subdirectories at any depth
- **Comment support**: Lines starting with `#` are treated as comments and ignored

### Implementation Details

- Added `_load_airflowignore()` function to read and parse `.airflowignore` files
- Added `_should_ignore_file()` function to check if a file matches any ignore patterns
- Integrated ignore logic into `load_yaml_dags()` to filter files before loading
- Patterns are matched against both filename and relative path from `dags_folder`
- Files outside `dags_folder` (e.g., symlinks) fall back to filename-only matching

## Usage Example

Create a `.airflowignore` file in your DAGs folder:

```
# Ignore test files
test_*.yml
*_test.yaml

# Ignore old DAGs
old_dags/*.yaml

# Ignore backup directory recursively
backup/**/*.yml
```

The `load_yaml_dags()` function will automatically respect these patterns:

```python
from dagfactory import load_yaml_dags

load_yaml_dags(globals_dict=globals(), dags_folder="/path/to/dags")
```

## Testing

- Added comprehensive test suite covering:
  - Loading ignore patterns from `.airflowignore` file
  - Pattern matching by filename and relative path
  - Recursive matching with `**` patterns
  - Comment and whitespace handling
  - Integration tests with actual DAG loading scenarios

## Additional

Fully backward compatible: If no `.airflowignore` file exists, the function behaves exactly as before.