### PR TITLE
Avoid error we're seeing in PRs from external contributors

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -244,7 +244,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
-          fail_ci_if_error: true
+          # Only fail CI if error when token is available (internal PRs and pushes)
+          # External PRs from forks don't have access to secrets
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 


### PR DESCRIPTION
Allow PRs from external contributors to not fail in the GH action Code-Coverage.
 
**Context**

DAG Factory pull requests from external contributors are failing in the action [Code-Coverage](https://github.com/astronomer/dag-factory/actions/runs/21713835922/job/62624598206?pr=653#logs), due to lack of the token. We removed this token as a security measurement.

**Current issue**

Example: https://github.com/astronomer/dag-factory/actions/runs/21713835922/job/62624598206?pr=653

```
==> Running upload-coverage
      ./codecov  upload-coverage --fail-on-error --git-service github --sha 2c1f51aa4683801e005c0ba387a199c644815d40 --file coverage.xml --gcov-executable gcov
info - 2026-02-05 13:48:18,724 -- ci service found: github-actions
warning - 2026-02-05 13:48:18,769 -- xcrun is not installed or can't be found.
warning - 2026-02-05 13:48:18,774 -- No gcov data found.
info - 2026-02-05 13:48:18,775 -- Generating coverage.xml report in /home/runner/work/dag-factory/dag-factory
info - 2026-02-05 13:48:18,993 -- Wrote XML report to coverage.xml
info - 2026-02-05 13:48:19,020 -- Found 1 coverage files to report
info - 2026-02-05 13:48:19,021 -- > /home/runner/work/dag-factory/dag-factory/coverage.xml
info - 2026-02-05 13:48:19,286 -- Process Upload complete
error - 2026-02-05 13:48:19,286 -- Upload failed: {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
    Exiting...
Error: Process completed with exit code 1.
```

**Solution**

This change:
- Sets `fail_ci_if_error` dynamically - It will be true when the `CODECOV_TOKEN` secret is available (internal PRs, pushes to main, releases), and false when it's not available (external PRs from forks).
- Keeps the token parameter - The token is still passed, but when it's empty (for fork PRs), the Codecov action will attempt a tokenless upload. If that fails on a protected branch, it will now just emit a warning instead of failing the entire CI.
 
This way:
- Internal contributors and pushes to main: Full coverage enforcement with the token
- External contributors (fork PRs): Coverage upload is attempted but won't block the PR if it fails

In the future, we can look into other ways of implementing the solution, such as requiring approval from maintainers, like we did in http://github.com/astronomer/astronomer-cosmos. However, for now, I do not think it justifies adding this maintenance overhead.