### PR TITLE
Unify import_from_string methods

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -14,18 +14,9 @@ from typing import Any, AnyStr, Dict, List, Match, Optional, Pattern, Tuple, Uni
 
 import pendulum
 import yaml
+from airflow.utils.module_loading import import_string
 
 from dagfactory.exceptions import DagFactoryException
-
-
-def _import_from_string(class_path):
-    """Dynamically import a class from a string."""
-    try:
-        module_path, class_name = class_path.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        return getattr(module, class_name)
-    except (ImportError, AttributeError) as e:
-        raise ImportError(f"Could not import '{class_path}': {e}")
 
 
 def get_datetime(date_value: Union[str, datetime, date], timezone: str = "UTC") -> datetime:
@@ -416,7 +407,7 @@ def cast_with_type(data):
             args = casted_args
 
         if "__type__" in data:
-            class_type = _import_from_string(data["__type__"])
+            class_type = import_string(data["__type__"])
             return class_type(*args, **processed)
 
         return processed

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -417,14 +417,14 @@ class DummyClassWithArgs:
 
 class TestCustomType:
 
-    @patch("dagfactory.utils._import_from_string")
+    @patch("dagfactory.utils.import_string")
     def test_cast_simple_dict_with_type(self, mock_import):
         mock_import.return_value = DummyClass
         data = {"__type__": "path.to.DummyClass", "a": 1, "b": 2}
         result = cast_with_type(data)
         assert result == DummyClass(a=1, b=2)
 
-    @patch("dagfactory.utils._import_from_string")
+    @patch("dagfactory.utils.import_string")
     def test_nested_dict(self, mock_import):
         mock_import.return_value = DummyClass
         data = {"__type__": "path.to.DummyClass", "a": {"__type__": "path.to.DummyClass", "a": 10, "b": 20}, "b": 5}
@@ -436,7 +436,7 @@ class TestCustomType:
         result = cast_with_type(data)
         assert result == [1, 2, {"x": 3}]
 
-    @patch("dagfactory.utils._import_from_string")
+    @patch("dagfactory.utils.import_string")
     def test_typed_list(self, mock_import):
         mock_import.return_value = DummyClass
         data = {


### PR DESCRIPTION
`_import_from_string` in `dagfactory/utils.py` is functionally equivalent to `airflow.utils.module_loading.import_string`, which was already used extensively throughout `dagfactory/dagbuilder.py`.

This PR replaces `_import_from_string` with `import_string` to simplify the code.