### PR TITLE
Ignore simple_auth_manager_passwords.json.generated from git

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -9,3 +9,4 @@ airflow-webserver.pid
 webserver_config.py
 airflow.cfg
 airflow.db
+simple_auth_manager_passwords.json.generated


### PR DESCRIPTION
Airflow 3 standalone creates `simple_auth_manager_passwords.json.generated` by default for user password during development. Such file should be ignored from version control.