### PR TITLE
Simplify DAG kwargs construction with a declarative spec

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -781,7 +781,6 @@ class DagBuilder:
         explicitly sets a parameter that is incompatible with the installed version.
         """
         dag_kwargs: Dict[str, Any] = {}
-        installed = INSTALLED_AIRFLOW_VERSION
 
         for spec in _DAG_PARAM_SPEC:
             key: str = spec["key"]
@@ -796,18 +795,18 @@ class DagBuilder:
             min_ver = spec.get("min_version")
             max_ver = spec.get("max_version")
 
-            if min_ver and installed < min_ver:
+            if min_ver and INSTALLED_AIRFLOW_VERSION < min_ver:
                 warnings.warn(
                     f"DAG parameter '{key}' requires Airflow >= {min_ver} "
-                    f"(installed: {AIRFLOW_VERSION}). The parameter will be ignored.",
+                    f"(installed: {INSTALLED_AIRFLOW_VERSION}). The parameter will be ignored.",
                     UserWarning,
                 )
                 continue
 
-            if max_ver and installed >= max_ver:
+            if max_ver and INSTALLED_AIRFLOW_VERSION >= max_ver:
                 warnings.warn(
                     f"DAG parameter '{key}' is not supported in Airflow >= {max_ver} "
-                    f"(installed: {AIRFLOW_VERSION}). The parameter will be ignored.",
+                    f"(installed: {INSTALLED_AIRFLOW_VERSION}). The parameter will be ignored.",
                     UserWarning,
                 )
                 continue

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from airflow import configuration
 from packaging import version
 
 from dagfactory.utils import check_dict_key
@@ -78,6 +77,46 @@ from dagfactory.exceptions import DagFactoryConfigException, DagFactoryException
 # these are params only used in the DAG factory, not in the tasks
 SYSTEM_PARAMS: List[str] = ["operator", "dependencies", "task_group_name", "parent_group_name"]
 INSTALLED_AIRFLOW_VERSION = version.parse(AIRFLOW_VERSION)
+
+# Declarative spec for DAG-level parameters passed to the DAG constructor.
+# Keys:
+#   key                    - the DAG constructor kwarg name (also the dag_params lookup key)
+#   required               - raise DagFactoryConfigException if absent
+#   min_version            - only applicable when Airflow >= this version (Version object); warn+skip if param is set below this
+#   max_version            - only applicable when Airflow <  this version (Version object); warn+skip if param is set at/above this
+#   deprecated_in_favor_of - this key is deprecated; when present, warn and write the value to the given canonical key.
+#                            must appear before the canonical key in the spec so the canonical key wins when both are set.
+#                            warning message is auto-generated from key and deprecated_in_favor_of.
+#   transform              - optional module-level callable applied to the raw dag_params value before writing to dag_kwargs.
+#                            must be defined at module level (before this spec) to avoid forward-reference issues.
+_DAG_PARAM_SPEC: List[Dict[str, Any]] = [
+    {"key": "dag_id", "required": True},
+    {"key": "dag_display_name", "min_version": version.parse("2.9.0")},
+    {"key": "description"},
+    {
+        "key": "concurrency",
+        "deprecated_in_favor_of": "max_active_tasks",
+    },
+    {"key": "max_active_tasks"},
+    {"key": "catchup"},
+    {"key": "max_active_runs"},
+    {"key": "dagrun_timeout"},
+    {"key": "default_view", "max_version": version.parse("3.0.0")},
+    {"key": "orientation", "max_version": version.parse("3.0.0")},
+    {"key": "template_searchpath"},
+    {"key": "render_template_as_native_obj"},
+    {"key": "sla_miss_callback", "max_version": version.parse("3.1.0")},
+    {"key": "on_success_callback"},
+    {"key": "on_failure_callback"},
+    {"key": "default_args"},
+    {"key": "doc_md"},
+    {"key": "access_control"},
+    {"key": "is_paused_upon_creation"},
+    {"key": "params"},
+    {"key": "start_date"},
+    {"key": "end_date"},
+    {"key": "timetable"},
+]
 
 
 class DagBuilder:
@@ -573,6 +612,7 @@ class DagBuilder:
             datasets_uri = utils.get_datasets_uri_yaml_file(file, list(dataset_map.keys()))
             return [Dataset(uri) for uri in datasets_uri]
 
+    # TODO: migrate configure_schedule() out of the class, so it can be used as a transform in _build_dag_kwargs().
     @staticmethod
     def configure_schedule(dag_params: Dict[str, Any], dag_kwargs: Dict[str, Any]) -> None:
         """
@@ -730,6 +770,63 @@ class DagBuilder:
 
         raise DagFactoryConfigException("'task_groups' must be either a mapping or a list of group configs")
 
+    @staticmethod
+    def _build_dag_kwargs(dag_params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Builds the kwargs dict passed to the DAG constructor by iterating over _DAG_PARAM_SPEC.
+
+        Only parameters explicitly present in dag_params are included; absent parameters are
+        left to Airflow's own defaults. Version-gated parameters are skipped silently when the
+        installed Airflow version does not apply, but a UserWarning is emitted when a user
+        explicitly sets a parameter that is incompatible with the installed version.
+        """
+        dag_kwargs: Dict[str, Any] = {}
+        installed = INSTALLED_AIRFLOW_VERSION
+
+        for spec in _DAG_PARAM_SPEC:
+            key: str = spec["key"]
+            param_present: bool = key in dag_params
+
+            if spec.get("required") and not param_present:
+                raise DagFactoryConfigException(f"Required DAG parameter '{key}' is missing.")
+
+            if not param_present:
+                continue
+
+            min_ver = spec.get("min_version")
+            max_ver = spec.get("max_version")
+
+            if min_ver and installed < min_ver:
+                warnings.warn(
+                    f"DAG parameter '{key}' requires Airflow >= {min_ver} "
+                    f"(installed: {AIRFLOW_VERSION}). The parameter will be ignored.",
+                    UserWarning,
+                )
+                continue
+
+            if max_ver and installed >= max_ver:
+                warnings.warn(
+                    f"DAG parameter '{key}' is not supported in Airflow >= {max_ver} "
+                    f"(installed: {AIRFLOW_VERSION}). The parameter will be ignored.",
+                    UserWarning,
+                )
+                continue
+
+            deprecated_in_favor_of: str = spec.get("deprecated_in_favor_of", "")
+            transform = spec.get("transform")
+            value = dag_params[key]
+            value = transform(value) if transform else value
+            if deprecated_in_favor_of:
+                warnings.warn(
+                    f"'{key}' is deprecated. Please use '{deprecated_in_favor_of}' instead.",
+                    DeprecationWarning,
+                )
+                dag_kwargs[deprecated_in_favor_of] = value
+            else:
+                dag_kwargs[key] = value
+
+        return dag_kwargs
+
     # pylint: disable=too-many-locals
     def build(self) -> Dict[str, Union[str, DAG]]:
         """
@@ -744,73 +841,9 @@ class DagBuilder:
 
         dag_params["task_groups"] = DagBuilder._normalise_task_groups_config(dag_params.get("task_groups"))
 
-        dag_kwargs: Dict[str, Any] = {}
-
-        dag_kwargs["dag_id"] = dag_params["dag_id"]
-        if version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0"):
-            dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
-
-        dag_kwargs["description"] = dag_params.get("description", None)
-
-        if "concurrency" in dag_params:
-            warnings.warn(
-                "`concurrency` param is deprecated. Please use max_active_tasks.", category=DeprecationWarning
-            )
-            dag_kwargs["max_active_tasks"] = dag_params["concurrency"]
-        else:
-            dag_kwargs["max_active_tasks"] = dag_params.get(
-                "max_active_tasks", configuration.conf.getint("core", "max_active_tasks_per_dag")
-            )
-
-        if dag_params.get("timetable"):
-            dag_kwargs["timetable"] = dag_params.get("timetable")
-
-        dag_kwargs["catchup"] = dag_params.get(
-            "catchup", configuration.conf.getboolean("scheduler", "catchup_by_default")
-        )
-
-        dag_kwargs["max_active_runs"] = dag_params.get(
-            "max_active_runs", configuration.conf.getint("core", "max_active_runs_per_dag")
-        )
-
-        dag_kwargs["dagrun_timeout"] = dag_params.get("dagrun_timeout", None)
-
-        if INSTALLED_AIRFLOW_VERSION.major < AIRFLOW3_MAJOR_VERSION:
-
-            dag_kwargs["default_view"] = dag_params.get(
-                "default_view", configuration.conf.get("webserver", "dag_default_view")
-            )
-
-            dag_kwargs["orientation"] = dag_params.get(
-                "orientation", configuration.conf.get("webserver", "dag_orientation")
-            )
-
-        dag_kwargs["template_searchpath"] = dag_params.get("template_searchpath", None)
-
-        dag_kwargs["render_template_as_native_obj"] = dag_params.get("render_template_as_native_obj", False)
-
-        if version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"):
-            # sla_miss_callback is fully-deprecated as of 3.1.0
-            dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)
-
-        dag_kwargs["on_success_callback"] = dag_params.get("on_success_callback", None)
-
-        dag_kwargs["on_failure_callback"] = dag_params.get("on_failure_callback", None)
-
-        dag_kwargs["default_args"] = dag_params.get("default_args", None)
-
-        dag_kwargs["doc_md"] = dag_params.get("doc_md", None)
-
-        dag_kwargs["access_control"] = dag_params.get("access_control", None)
-
-        dag_kwargs["is_paused_upon_creation"] = dag_params.get("is_paused_upon_creation", None)
+        dag_kwargs: Dict[str, Any] = DagBuilder._build_dag_kwargs(dag_params)
 
         DagBuilder.configure_schedule(dag_params, dag_kwargs)
-
-        dag_kwargs["params"] = dag_params.get("params", None)
-
-        dag_kwargs["start_date"] = dag_params.get("start_date", None)
-        dag_kwargs["end_date"] = dag_params.get("end_date", None)
 
         dag: DAG = DAG(**dag_kwargs)
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1558,3 +1558,175 @@ class TestTopologicalSortTasks:
         assert task_names.index("task1") < task_names.index("task3")
         assert task_names.index("task2") < task_names.index("task4")
         assert task_names.index("task3") < task_names.index("task4")
+
+
+# ---------------------------------------------------------------------------
+# Tests for DagBuilder._build_dag_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDagKwargs:
+    """Unit tests for the spec-driven _build_dag_kwargs helper."""
+
+    def _call(self, dag_params):
+        return dagbuilder.DagBuilder._build_dag_kwargs(dag_params)
+
+    # ------------------------------------------------------------------
+    # Basic: only params present in dag_params are forwarded
+    # ------------------------------------------------------------------
+
+    def test_only_present_params_are_included(self):
+        result = self._call({"dag_id": "my_dag"})
+        assert result == {"dag_id": "my_dag"}
+
+    def test_multiple_simple_params(self):
+        result = self._call({"dag_id": "my_dag", "catchup": False, "max_active_runs": 3})
+        assert result["dag_id"] == "my_dag"
+        assert result["catchup"] is False
+        assert result["max_active_runs"] == 3
+        # Params not in dag_params must not appear
+        assert "description" not in result
+        assert "dagrun_timeout" not in result
+
+    # ------------------------------------------------------------------
+    # required flag
+    # ------------------------------------------------------------------
+
+    def test_required_param_missing_raises(self):
+        with pytest.raises(dagbuilder.DagFactoryConfigException, match="dag_id"):
+            self._call({})
+
+    # ------------------------------------------------------------------
+    # deprecated_alias: concurrency → max_active_tasks
+    # ------------------------------------------------------------------
+    # deprecated_in_favor_of
+    # ------------------------------------------------------------------
+
+    def test_deprecated_param_emits_warning_and_maps_to_canonical(self):
+        with pytest.warns(DeprecationWarning, match="concurrency"):
+            result = self._call({"dag_id": "d", "concurrency": 5})
+        assert result["max_active_tasks"] == 5
+        assert "concurrency" not in result
+
+    def test_canonical_key_used_without_warning_when_deprecated_absent(self):
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", DeprecationWarning)
+            result = self._call({"dag_id": "d", "max_active_tasks": 7})
+        assert result["max_active_tasks"] == 7
+
+    def test_canonical_wins_when_both_deprecated_and_canonical_set(self):
+        # concurrency entry comes first in spec and writes max_active_tasks=5,
+        # then max_active_tasks entry overwrites with the canonical value 7.
+        with pytest.warns(DeprecationWarning, match="concurrency"):
+            result = self._call({"dag_id": "d", "concurrency": 5, "max_active_tasks": 7})
+        assert result["max_active_tasks"] == 7
+
+    # ------------------------------------------------------------------
+    # min_version gating
+    # ------------------------------------------------------------------
+
+    def test_min_version_param_skipped_silently_when_absent(self):
+        # dag_display_name requires >= 2.9.0; if not set, no warning, just absent
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            result = self._call({"dag_id": "d"})
+        assert "dag_display_name" not in result
+
+    def test_min_version_param_included_when_version_satisfied(self):
+        # Patch INSTALLED_AIRFLOW_VERSION to a version that satisfies 2.9.0
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("2.9.0")):
+            result = self._call({"dag_id": "d", "dag_display_name": "Pretty DAG"})
+        assert result.get("dag_display_name") == "Pretty DAG"
+
+    def test_min_version_violation_emits_warning_and_ignores_param(self):
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("2.8.0")):
+            with pytest.warns(UserWarning, match="dag_display_name"):
+                result = self._call({"dag_id": "d", "dag_display_name": "Pretty DAG"})
+        assert "dag_display_name" not in result
+
+    # ------------------------------------------------------------------
+    # max_version gating
+    # ------------------------------------------------------------------
+
+    def test_max_version_param_included_when_version_below_limit(self):
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("2.10.0")):
+            result = self._call({"dag_id": "d", "default_view": "graph"})
+        assert result.get("default_view") == "graph"
+
+    def test_max_version_violation_emits_warning_and_ignores_param(self):
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("3.0.0")):
+            with pytest.warns(UserWarning, match="default_view"):
+                result = self._call({"dag_id": "d", "default_view": "graph"})
+        assert "default_view" not in result
+
+    def test_max_version_param_absent_no_warning_even_above_limit(self):
+        # default_view not set → no warning, even on Airflow 3+
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+        import warnings as _warnings
+
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("3.0.0")):
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("error", UserWarning)
+                result = self._call({"dag_id": "d"})
+        assert "default_view" not in result
+
+    def test_sla_miss_callback_max_version(self):
+        from packaging import version as pkg_version
+        from unittest.mock import patch
+
+        # Included on Airflow < 3.1.0
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("3.0.0")):
+            result = self._call({"dag_id": "d", "sla_miss_callback": "my_cb"})
+        assert result.get("sla_miss_callback") == "my_cb"
+
+        # Ignored on Airflow >= 3.1.0
+        with patch.object(dagbuilder, "INSTALLED_AIRFLOW_VERSION", pkg_version.parse("3.1.0")):
+            with pytest.warns(UserWarning, match="sla_miss_callback"):
+                result = self._call({"dag_id": "d", "sla_miss_callback": "my_cb"})
+        assert "sla_miss_callback" not in result
+
+    # ------------------------------------------------------------------
+    # transform
+    # ------------------------------------------------------------------
+
+    def test_transform_is_applied_to_value(self):
+        from dagfactory import dagbuilder as db
+        from dagfactory.dagbuilder import _DAG_PARAM_SPEC
+
+        # Temporarily inject a spec entry with a transform
+        transform_called_with = []
+
+        def my_transform(value):
+            transform_called_with.append(value)
+            return value * 2
+
+        extra = {"key": "max_active_runs", "transform": my_transform}
+        patched_spec = _DAG_PARAM_SPEC + [extra]
+
+        with __import__("unittest.mock", fromlist=["patch"]).patch.object(db, "_DAG_PARAM_SPEC", patched_spec):
+            result = self._call({"dag_id": "d", "max_active_runs": 3})
+
+        assert transform_called_with == [3]
+        # The last entry in the patched spec overwrites the earlier plain entry
+        assert result["max_active_runs"] == 6
+
+    def test_no_transform_copies_value_directly(self):
+        result = self._call({"dag_id": "d", "max_active_runs": 4})
+        assert result["max_active_runs"] == 4

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1720,7 +1720,7 @@ class TestBuildDagKwargs:
         extra = {"key": "max_active_runs", "transform": my_transform}
         patched_spec = _DAG_PARAM_SPEC + [extra]
 
-        with __import__("unittest.mock", fromlist=["patch"]).patch.object(db, "_DAG_PARAM_SPEC", patched_spec):
+        with patch.object(db, "_DAG_PARAM_SPEC", patched_spec):
             result = self._call({"dag_id": "d", "max_active_runs": 3})
 
         assert transform_called_with == [3]


### PR DESCRIPTION
Resolves https://github.com/astronomer/dag-factory/issues/587

Key changes:
1. This PR uses dict-based declarative spec defining DAG arguments, achieving unified argument definition like version check.
2. Always fall back to Airflow's own default value or behavior when key not set.

Future works: task-level spec will be added in the follow-up PR