### PR TITLE
Drop support for Airflow < 2.9

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, drop_airflow_le_2.9]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -62,29 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        airflow-version:
-          ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
-        exclude:
-          - python-version: "3.11"
-            airflow-version: "2.4"
-          - python-version: "3.11"
-            airflow-version: "2.5"
-          - python-version: "3.11"
-            airflow-version: "2.6"
-          # Apache Airflow versions prior to 2.9.0 have not been tested with Python 3.12.
-          # Official support for Python 3.12 and the corresponding constraints.txt are available only for Apache Airflow >= 2.9.0.
-          # See: https://github.com/apache/airflow/tree/2.9.0?tab=readme-ov-file#requirements
-          # See: https://github.com/apache/airflow/tree/2.8.4?tab=readme-ov-file#requirements
-          - python-version: "3.12"
-            airflow-version: "2.4"
-          - python-version: "3.12"
-            airflow-version: "2.5"
-          - python-version: "3.12"
-            airflow-version: "2.6"
-          - python-version: "3.12"
-            airflow-version: "2.7"
-          - python-version: "3.12"
-            airflow-version: "2.8"
+        airflow-version: ["2.9", "2.10", "2.11", "3.0"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,29 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        airflow-version:
-          ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
-        exclude:
-          - python-version: "3.11"
-            airflow-version: "2.4"
-          - python-version: "3.11"
-            airflow-version: "2.5"
-          - python-version: "3.11"
-            airflow-version: "2.6"
-          # Apache Airflow versions prior to 2.9.0 have not been tested with Python 3.12.
-          # Official support for Python 3.12 and the corresponding constraints.txt are available only for Apache Airflow >= 2.9.0.
-          # See: https://github.com/apache/airflow/tree/2.9.0?tab=readme-ov-file#requirements
-          # See: https://github.com/apache/airflow/tree/2.8.4?tab=readme-ov-file#requirements
-          - python-version: "3.12"
-            airflow-version: "2.4"
-          - python-version: "3.12"
-            airflow-version: "2.5"
-          - python-version: "3.12"
-            airflow-version: "2.6"
-          - python-version: "3.12"
-            airflow-version: "2.7"
-          - python-version: "3.12"
-            airflow-version: "2.8"
+        airflow-version: ["2.9", "2.10", "2.11", "3.0"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, drop_airflow_le_2.9]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ declaratively via configuration files.
 The minimum requirements for **dag-factory** are:
 
 - Python 3.10.0+
-- [Apache Airflow®](https://airflow.apache.org) 2.4+
+- [Apache Airflow®](https://airflow.apache.org) 2.9+
 
 For a gentle introduction, please take a look at our [Quickstart Guide](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/). For more examples, please see the
 [examples](/examples/dags/) folder.

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -178,25 +178,19 @@ class DagBuilder:
                         parameters=dag_params, callback_type=callback_type, has_name_and_file=True
                     )
 
-            # SLAs are defined at the DAG-level, and will be applied to every task.
-            # https://www.astronomer.io/docs/learn/error-notifications-in-airflow/. Here, we are not going to add
-            # callbacks for sla_miss_callback, or on_skipped_callback if the Airflow version is less than 2.7.0
-            if (callback_type != "sla_miss_callback") or not (
-                callback_type == "on_skipped_callback" and version.parse(AIRFLOW_VERSION) < version.parse("2.7.0")
-            ):
-                # Next, check for a callback at the Task-level using default_args
-                if utils.check_dict_key(dag_params["default_args"], callback_type):
-                    dag_params["default_args"][callback_type]: Callable = self.set_callback(
-                        parameters=dag_params["default_args"], callback_type=callback_type
-                    )
+            # Next, check for a callback at the Task-level using default_args
+            if utils.check_dict_key(dag_params["default_args"], callback_type):
+                dag_params["default_args"][callback_type]: Callable = self.set_callback(
+                    parameters=dag_params["default_args"], callback_type=callback_type
+                )
 
-                # Finally, check for file path and name at the Task-level using default_args
-                if utils.check_dict_key(dag_params["default_args"], f"{callback_type}_name") and utils.check_dict_key(
-                    dag_params["default_args"], f"{callback_type}_file"
-                ):
-                    dag_params["default_args"][callback_type] = self.set_callback(
-                        parameters=dag_params["default_args"], callback_type=callback_type, has_name_and_file=True
-                    )
+            # Finally, check for file path and name at the Task-level using default_args
+            if utils.check_dict_key(dag_params["default_args"], f"{callback_type}_name") and utils.check_dict_key(
+                dag_params["default_args"], f"{callback_type}_file"
+            ):
+                dag_params["default_args"][callback_type] = self.set_callback(
+                    parameters=dag_params["default_args"], callback_type=callback_type, has_name_and_file=True
+                )
 
         if utils.check_dict_key(dag_params, "template_searchpath"):
             if isinstance(dag_params["template_searchpath"], (list, str)) and utils.check_template_searchpath(
@@ -358,13 +352,7 @@ class DagBuilder:
 
         :param task_group_conf: dict containing the configuration of the TaskGroup
         """
-        # The Airflow version needs to be at least 2.2.0, and default args must be present. Basically saying here: if
-        # it's not the case that we're using at least Airflow 2.2.0 and default_args are present, then return the
-        # TaskGroup configuration without doing anything
-        if not (
-            version.parse(AIRFLOW_VERSION) >= version.parse("2.2.0")
-            and isinstance(task_group_conf.get("default_args"), dict)
-        ):
+        if not isinstance(task_group_conf.get("default_args"), dict):
             return task_group_conf
 
         # Check the callback types that can be in the default_args of the TaskGroup
@@ -375,10 +363,6 @@ class DagBuilder:
             "on_retry_callback",
             "on_skipped_callback",  # This is only available AIRFLOW_VERSION >= 2.7.0
         ]:
-            # on_skipped_callback can only be added to the default_args of a TaskGroup for AIRFLOW_VERSION >= 2.7.0
-            if callback_type == "on_skipped_callback" and version.parse(AIRFLOW_VERSION) < version.parse("2.7.0"):
-                continue
-
             # First, check for a str, str with params, or provider callback
             if utils.check_dict_key(task_group_conf["default_args"], callback_type):
                 task_group_conf["default_args"][callback_type]: Callable = DagBuilder.set_callback(
@@ -573,17 +557,10 @@ class DagBuilder:
         :returns: The result of the condition evaluation if `condition_string` is provided, otherwise a list of `Dataset` objects.
         :rtype: Any
         """
-        is_airflow_version_at_least_2_9 = version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0")
         datasets_conditions, dataset_map = DagBuilder._extract_and_transform_datasets(datasets_conditions)
-
-        if is_airflow_version_at_least_2_9:
-            map_datasets = utils.get_datasets_map_uri_yaml_file(file, list(dataset_map.keys()))
-            dataset_map = {alias_dataset: Dataset(uri) for alias_dataset, uri in map_datasets.items()}
-            evaluated_condition = DagBuilder.safe_eval(datasets_conditions, dataset_map)
-            return evaluated_condition
-        else:
-            datasets_uri = utils.get_datasets_uri_yaml_file(file, list(dataset_map.keys()))
-            return [Dataset(uri) for uri in datasets_uri]
+        map_datasets = utils.get_datasets_map_uri_yaml_file(file, list(dataset_map.keys()))
+        dataset_map = {alias_dataset: Dataset(uri) for alias_dataset, uri in map_datasets.items()}
+        return DagBuilder.safe_eval(datasets_conditions, dataset_map)
 
     @staticmethod
     def configure_schedule(dag_params: Dict[str, Any], dag_kwargs: Dict[str, Any]) -> None:
@@ -609,7 +586,6 @@ class DagBuilder:
         schedule_key = "schedule"
 
         if INSTALLED_AIRFLOW_VERSION.major < AIRFLOW3_MAJOR_VERSION:
-            is_airflow_version_at_least_2_9 = version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0")
             has_schedule_attr = utils.check_dict_key(dag_params, "schedule")
 
             if has_schedule_attr:
@@ -625,7 +601,7 @@ class DagBuilder:
                     datasets_conditions: str = utils.parse_list_datasets(datasets)
                     dag_kwargs[schedule_key] = DagBuilder.process_file_with_datasets(file, datasets_conditions)
 
-                elif has_datasets_attr and is_airflow_version_at_least_2_9:
+                elif has_datasets_attr:
                     datasets = schedule["datasets"]
                     datasets_conditions: str = utils.parse_list_datasets(datasets)
                     dag_kwargs[schedule_key] = DagBuilder.evaluate_condition_with_datasets(datasets_conditions)
@@ -759,8 +735,7 @@ class DagBuilder:
         dag_kwargs: Dict[str, Any] = {}
 
         dag_kwargs["dag_id"] = dag_params["dag_id"]
-        if version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0"):
-            dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
+        dag_kwargs["dag_display_name"] = dag_params.get("dag_display_name", dag_params["dag_id"])
 
         dag_kwargs["description"] = dag_params.get("description", None)
 
@@ -1064,11 +1039,6 @@ class DagBuilder:
 
         expand_kwargs = decorator_kwargs.pop("expand", {})
         partial_kwargs = decorator_kwargs.pop("partial", {})
-
-        if ("map_index_template" in decorator_kwargs) and (version.parse(AIRFLOW_VERSION) < version.parse("2.7.0")):
-            raise DagFactoryConfigException(
-                "The dynamic task mapping argument `map_index_template` is only supported since Airflow 2.7"
-            )
 
         if expand_kwargs and partial_kwargs:
             if callable_kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "apache-airflow>=2.4",
+    "apache-airflow>=2.9",
     "pyyaml",
     "packaging",
     "typer"
@@ -79,7 +79,7 @@ dev-dependencies = [
 
 # Respect existing constraints for Airflow compatibility
 constraint-dependencies = [
-    "apache-airflow>=2.4",
+    "apache-airflow>=2.9",
 ]
 
 [tool.uv.workspace]
@@ -109,15 +109,7 @@ dependencies = [
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.10"]
-airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
-
-[[tool.hatch.envs.tests.matrix]]
-python = ["3.11"]
-airflow = ["2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
-
-[[tool.hatch.envs.tests.matrix]]
-python = ["3.12"]
+python = ["3.10", "3.11", "3.12"]
 airflow = ["2.9", "2.10", "2.11", "3.0"]
 
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -596,8 +596,7 @@ def test_build():
     assert isinstance(actual["dag"], DAG)
     assert len(actual["dag"].tasks) == 3
     assert actual["dag"].task_dict["task_1"].downstream_task_ids == {"task_2", "task_3"}
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.9.0"):
-        assert actual["dag"].dag_display_name == "Pretty example dag"
+    assert actual["dag"].dag_display_name == "Pretty example dag"
     assert sorted(actual["dag"].tags) == sorted(["tag1", "tag2", "dagfactory"])
 
 
@@ -747,16 +746,7 @@ def test_set_callback_exceptions():
     Validate that exceptions are being throw for an incompatible version of Airflow, as well as for an invalid type
     passed to the parameter config.
     """
-    # Test a versioning exception
-    if version.parse(AIRFLOW_VERSION) < version.parse("2.0.0"):
-        error_message = "Cannot parse callbacks with an Airflow version less than 2.0.0"
-        with pytest.raises(DagFactoryConfigException, match=error_message):
-            DagBuilder.set_callback(
-                parameters={"dummy_key": "dummy_value"},
-                callback_type="on_execute_callback",
-            )
-
-    # Now, test an exception parsing the parameters dictionary
+    # Test an exception parsing the parameters dictionary
     invalid_type_passed_message = "Invalid type passed to on_execute_callback"
     with pytest.raises(DagFactoryConfigException, match=invalid_type_passed_message):
         DagBuilder.set_callback(
@@ -798,7 +788,7 @@ def test_make_dag_with_callbacks():
     assert dag.on_failure_callback.__name__ == "print_context_callback"
 
     # sla_miss_callback is removed as of Airflow 3.1.0
-    if version.parse("2.6.0") < version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"):
+    if version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"):
         from airflow.providers.slack.notifications.slack import send_slack_notification
 
         dag_config_callbacks__with_provider = dict(DAG_CONFIG_CALLBACKS)
@@ -848,22 +838,19 @@ def test_make_dag_with_callbacks_default_args():
         "on_retry_callback",
         "on_skipped_callback",
     ):
-        # on_skipped_callback could only be added to default_args starting in Airflow version 2.7.0
-        # TODO: Address this, this should be 2.7.0
-        if not (version.parse(AIRFLOW_VERSION) < version.parse("2.9.0") and callback_type == "on_skipped_callback"):
-            assert callback_type in default_args
-            assert callable(default_args.get(callback_type))
-            assert default_args.get(callback_type).__name__ == "print_context_callback"
+        assert callback_type in default_args
+        assert callable(default_args.get(callback_type))
+        assert default_args.get(callback_type).__name__ == "print_context_callback"
 
-            # Assert that these callbacks have been applied at the Task-level
-            assert callback_type in task_1.__dict__
-            # Airflow 3 callback type is sequence
-            if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
-                assert callable(task_1.__dict__[callback_type][0])
-                assert task_1.__dict__[callback_type][0].__name__ == "print_context_callback"
-            else:
-                assert callable(task_1.__dict__[callback_type])
-                assert task_1.__dict__[callback_type].__name__ == "print_context_callback"
+        # Assert that these callbacks have been applied at the Task-level
+        assert callback_type in task_1.__dict__
+        # Airflow 3 callback type is sequence
+        if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
+            assert callable(task_1.__dict__[callback_type][0])
+            assert task_1.__dict__[callback_type][0].__name__ == "print_context_callback"
+        else:
+            assert callable(task_1.__dict__[callback_type])
+            assert task_1.__dict__[callback_type].__name__ == "print_context_callback"
 
         # Assert that these callbacks have been applied at the Task-level
         assert "on_failure_callback" in task_1.__dict__
@@ -893,24 +880,17 @@ def test_make_dag_with_task_group_callbacks():
     # Import the DAG using the callback config that was build above
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG_TASK_GROUP_WITH_CALLBACKS, DEFAULT_CONFIG)
 
-    # This will be done only once; validate the exception that is raised if trying to use an invalid version of Airflow
-    # when building TaskGroups
-    if version.parse(AIRFLOW_VERSION) < version.parse("2.2.0"):
-        error_message = "`task_groups` key can only be used with Airflow 2.x.x"
-        with pytest.raises(Exception, match=error_message):
-            td.build()
-    else:
-        dag = td.build()["dag"]  # Also, pull the dag
+    dag = td.build()["dag"]
 
-        # Basic checks to ensure the DAG was built as expected
-        if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-            assert dag.task_count == 4
-        assert len([task for task in dag.task_dict.keys() if task.startswith("task_group_1")]) == 3
-        assert (
-            "task_group_1.task_1" in dag.task_dict
-            and "task_group_1.task_2" in dag.task_dict
-            and "task_group_1.task_3" in dag.task_dict
-        )
+    # Basic checks to ensure the DAG was built as expected
+    if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
+        assert dag.task_count == 4
+    assert len([task for task in dag.task_dict.keys() if task.startswith("task_group_1")]) == 3
+    assert (
+        "task_group_1.task_1" in dag.task_dict
+        and "task_group_1.task_2" in dag.task_dict
+        and "task_group_1.task_3" in dag.task_dict
+    )
 
 
 @pytest.mark.callbacks
@@ -929,45 +909,43 @@ def test_make_dag_with_task_group_callbacks_default_args():
     # if the version was not met. Here, we'll pass testing
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG_TASK_GROUP_WITH_CALLBACKS, DEFAULT_CONFIG)
 
-    # TODO: This should be 2.2.0
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.3.0"):  # This is a work-around for now
-        dag = td.build()["dag"]  # Also, pull the dag
+    dag = td.build()["dag"]
 
-        # Now, loop through each of the callback types and validate
-        assert "task_group_1" in td.dag_config["task_groups"]
-        task_group_default_args = td.dag_config["task_groups"]["task_group_1"]["default_args"]
+    # Now, loop through each of the callback types and validate
+    assert "task_group_1" in td.dag_config["task_groups"]
+    task_group_default_args = td.dag_config["task_groups"]["task_group_1"]["default_args"]
 
-        # Test that the on_execute_callback configured in the default_args of the TaskGroup are passed down to the Tasks
-        # grouped into task_group_1
-        assert "on_execute_callback" in task_group_default_args and "on_failure_callback" in task_group_default_args
-        # Airflow 3 callback type is sequence
-        if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
-            assert callable(dag.task_dict["task_group_1.task_1"].on_execute_callback[0])
-            assert dag.task_dict["task_group_1.task_1"].on_execute_callback[0].__name__ == "print_context_callback"
-        else:
-            assert callable(dag.task_dict["task_group_1.task_1"].on_execute_callback)
-            assert dag.task_dict["task_group_1.task_1"].on_execute_callback.__name__ == "print_context_callback"
+    # Test that the on_execute_callback configured in the default_args of the TaskGroup are passed down to the Tasks
+    # grouped into task_group_1
+    assert "on_execute_callback" in task_group_default_args and "on_failure_callback" in task_group_default_args
+    # Airflow 3 callback type is sequence
+    if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
+        assert callable(dag.task_dict["task_group_1.task_1"].on_execute_callback[0])
+        assert dag.task_dict["task_group_1.task_1"].on_execute_callback[0].__name__ == "print_context_callback"
+    else:
+        assert callable(dag.task_dict["task_group_1.task_1"].on_execute_callback)
+        assert dag.task_dict["task_group_1.task_1"].on_execute_callback.__name__ == "print_context_callback"
 
-        # task_2 overrides the on_failure_callback configured in the default_args of task_group_1. Below, this is
-        # validated but checking the type, "callab-ility", name, and parameters configured with it
-        # Airflow 3 callback type is sequence
-        if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
-            assert isinstance(dag.task_dict["task_group_1.task_2"].on_failure_callback[0], functools.partial)
-            assert callable(dag.task_dict["task_group_1.task_2"].on_failure_callback[0])
-            assert (
-                dag.task_dict["task_group_1.task_2"].on_failure_callback[0].func.__name__
-                == "empty_callback_with_params"
-            )
-            assert "param_1" in dag.task_dict["task_group_1.task_2"].on_failure_callback[0].keywords
-            assert dag.task_dict["task_group_1.task_2"].on_failure_callback[0].keywords.get("param_1") == "value_1"
-        else:
-            assert isinstance(dag.task_dict["task_group_1.task_2"].on_failure_callback, functools.partial)
-            assert callable(dag.task_dict["task_group_1.task_2"].on_failure_callback)
-            assert (
-                dag.task_dict["task_group_1.task_2"].on_failure_callback.func.__name__ == "empty_callback_with_params"
-            )
-            assert "param_1" in dag.task_dict["task_group_1.task_2"].on_failure_callback.keywords
-            assert dag.task_dict["task_group_1.task_2"].on_failure_callback.keywords.get("param_1") == "value_1"
+    # task_2 overrides the on_failure_callback configured in the default_args of task_group_1. Below, this is
+    # validated but checking the type, "callab-ility", name, and parameters configured with it
+    # Airflow 3 callback type is sequence
+    if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
+        assert isinstance(dag.task_dict["task_group_1.task_2"].on_failure_callback[0], functools.partial)
+        assert callable(dag.task_dict["task_group_1.task_2"].on_failure_callback[0])
+        assert (
+            dag.task_dict["task_group_1.task_2"].on_failure_callback[0].func.__name__
+            == "empty_callback_with_params"
+        )
+        assert "param_1" in dag.task_dict["task_group_1.task_2"].on_failure_callback[0].keywords
+        assert dag.task_dict["task_group_1.task_2"].on_failure_callback[0].keywords.get("param_1") == "value_1"
+    else:
+        assert isinstance(dag.task_dict["task_group_1.task_2"].on_failure_callback, functools.partial)
+        assert callable(dag.task_dict["task_group_1.task_2"].on_failure_callback)
+        assert (
+            dag.task_dict["task_group_1.task_2"].on_failure_callback.func.__name__ == "empty_callback_with_params"
+        )
+        assert "param_1" in dag.task_dict["task_group_1.task_2"].on_failure_callback.keywords
+        assert dag.task_dict["task_group_1.task_2"].on_failure_callback.keywords.get("param_1") == "value_1"
 
 
 @pytest.mark.callbacks
@@ -1063,44 +1041,35 @@ def test_make_task_with_duplicated_partial_kwargs():
 
 def test_dynamic_task_mapping():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG_DYNAMIC_TASK_MAPPING, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) < version.parse("2.3.0"):
-        error_message = "Dynamic task mapping available only in Airflow >= 2.3.0"
-        with pytest.raises(Exception, match=error_message):
-            td.build()
-    else:
-        operator = get_python_operator_path()
-        task_params = {
-            "task_id": "process",
-            "python_callable_name": "expand_task",
-            "python_callable_file": os.path.realpath(__file__),
-            "partial": {"op_kwargs": {"test_id": "test"}},
-            "expand": {"op_args": {"request_output": "request.output"}},
-        }
-        actual = td.make_task(operator, task_params)
-        assert isinstance(actual, MappedOperator)
+    operator = get_python_operator_path()
+    task_params = {
+        "task_id": "process",
+        "python_callable_name": "expand_task",
+        "python_callable_file": os.path.realpath(__file__),
+        "partial": {"op_kwargs": {"test_id": "test"}},
+        "expand": {"op_args": {"request_output": "request.output"}},
+    }
+    actual = td.make_task(operator, task_params)
+    assert isinstance(actual, MappedOperator)
 
 
 def test_replace_expand_string_with_xcom():
+    from airflow.models.xcom_arg import XComArg
+
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG_DYNAMIC_TASK_MAPPING, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) < version.parse("2.3.0"):
-        with pytest.raises(Exception):
-            td.build()
-    else:
-        from airflow.models.xcom_arg import XComArg
+    task_conf_output = {"expand": {"key_1": "task_1.output"}}
+    task_conf_xcomarg = {"expand": {"key_1": "XcomArg(task_1)"}}
 
-        task_conf_output = {"expand": {"key_1": "task_1.output"}}
-        task_conf_xcomarg = {"expand": {"key_1": "XcomArg(task_1)"}}
+    task1 = PythonOperator(
+        task_id="task1",
+        python_callable=lambda: print("hello"),
+    )
 
-        task1 = PythonOperator(
-            task_id="task1",
-            python_callable=lambda: print("hello"),
-        )
-
-        tasks_dict = {"task_1": task1}
-        updated_task_conf_output = dagbuilder.DagBuilder.replace_expand_values(task_conf_output, tasks_dict)
-        updated_task_conf_xcomarg = dagbuilder.DagBuilder.replace_expand_values(task_conf_xcomarg, tasks_dict)
-        assert updated_task_conf_output["expand"]["key_1"] == XComArg(tasks_dict["task_1"])
-        assert updated_task_conf_xcomarg["expand"]["key_1"] == XComArg(tasks_dict["task_1"])
+    tasks_dict = {"task_1": task1}
+    updated_task_conf_output = dagbuilder.DagBuilder.replace_expand_values(task_conf_output, tasks_dict)
+    updated_task_conf_xcomarg = dagbuilder.DagBuilder.replace_expand_values(task_conf_xcomarg, tasks_dict)
+    assert updated_task_conf_output["expand"]["key_1"] == XComArg(tasks_dict["task_1"])
+    assert updated_task_conf_xcomarg["expand"]["key_1"] == XComArg(tasks_dict["task_1"])
 
 
 @pytest.mark.skipif(
@@ -1184,8 +1153,8 @@ def test_make_nested_task_groups():
 class TestSchedule:
 
     @pytest.mark.skipif(
-        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
-        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+        INSTALLED_AIRFLOW_VERSION >= version.parse("3.0.0"),
+        reason="Requires Airflow < 3.0.0",
     )
     def test_asset_schedule_list_of_dataset(self):
         schedule_data = load_yaml_file(str(schedule_path / "dataset_as_list.yml"))
@@ -1195,8 +1164,8 @@ class TestSchedule:
         ]
 
     @pytest.mark.skipif(
-        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
-        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+        INSTALLED_AIRFLOW_VERSION >= version.parse("3.0.0"),
+        reason="Requires Airflow < 3.0.0",
     )
     def test_asset_schedule_list_of_dataset_object(self):
         from airflow.datasets import Dataset, DatasetAll, DatasetAny
@@ -1211,8 +1180,8 @@ class TestSchedule:
         assert schedule_data["schedule"].__eq__(expected)
 
     @pytest.mark.skipif(
-        not (version.parse("2.8.0") < INSTALLED_AIRFLOW_VERSION < version.parse("3.0.0")),
-        reason="Requires Airflow < 3.0.0 and > 2.8.0",
+        INSTALLED_AIRFLOW_VERSION >= version.parse("3.0.0"),
+        reason="Requires Airflow < 3.0.0",
     )
     def test_asset_schedule_list_of_dataset_nested(self):
         from airflow.datasets import Dataset, DatasetAll, DatasetAny

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -357,20 +357,10 @@ def test_generate_dags_invalid():
         )
 
 
-@pytest.mark.skipif(version.parse(AIRFLOW_VERSION) < version.parse("2.7.0"), reason="Requires Airflow >= 2.7.0")
-def test_kubernetes_pod_operator_dag_gte_2_7():
+def test_kubernetes_pod_operator_dag():
     load_yaml_dags(
         globals_dict=globals(),
         config_filepath=DAG_FACTORY_KUBERNETES_POD_OPERATOR,
-    )
-    assert "example_dag" in globals()
-
-
-@pytest.mark.skipif(version.parse(AIRFLOW_VERSION) >= version.parse("2.7.0"), reason="Requires Airflow < 2.7.0")
-def test_kubernetes_pod_operator_dag_lt_2_7():
-    load_yaml_dags(
-        globals_dict=globals(),
-        config_filepath=DAG_FACTORY_KUBERNETES_POD_OPERATOR_LT_2_7,
     )
     assert "example_dag" in globals()
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -19,16 +19,7 @@ AIRFLOW_VERSION = Version(airflow.__version__)
 # TODO: Enable asset_triggered_dags.py once https://github.com/apache/airflow/issues/51644 is solved
 IGNORED_DAG_FILES = ["example_callbacks.py", "example_http_operator_task.py", "asset_triggered_dags.py", "kpo.py"]
 
-MIN_VER_DAG_FILE_VER: dict[str, list[str]] = {
-    "2.5": [
-        "example_pypi_stats_dagfactory",
-        "example_hackernews_dagfactory",
-        "example_hackernews_plain_airflow",
-        "example_pypi_stats_plain_airflow",
-    ],
-    "2.7": ["example_timetable_schedule.py"],
-    "2.9": ["example_map_index_template.py", "example_object_storage.py"],
-}
+MIN_VER_DAG_FILE_VER: dict[str, list[str]] = {}
 
 MAX_VER_DAG_FILE_VER: dict[str, list[str]] = {
     "3.0": ["example_timetable_schedule.py"],  # `timetable` parameter removed in Airflow 3.0
@@ -96,13 +87,7 @@ def test_example_dag(session, dag_id: str):
     dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
 
-    # This feature is available since Airflow 2.5:
-    # https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-0-2022-12-02
-    dag_run = None
-    if AIRFLOW_VERSION >= Version("2.5"):
-        dag_run = dag.test()
-    else:
-        dag_run = test_utils.run_dag(dag)
+    dag_run = dag.test()
 
     if dag_run is not None:
         assert dag_run.state == DagRunState.SUCCESS

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -182,11 +182,7 @@ def one_hour_ago(execution_date: datetime):
 
 
 def get_http_sensor_path():
-    airflow_version = version.parse(AIRFLOW_VERSION)
-    if airflow_version < version.parse("2.4.0"):
-        return "airflow.sensors.http_sensor.HttpSensor"
-    else:
-        return "airflow.providers.http.sensors.http.HttpSensor"
+    return "airflow.providers.http.sensors.http.HttpSensor"
 
 
 def get_bash_operator_path():

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [manifest]
-constraints = [{ name = "apache-airflow", specifier = ">=2.4" }]
+constraints = [{ name = "apache-airflow", specifier = ">=2.9" }]
 
 [[package]]
 name = "a2wsgi"
@@ -957,7 +957,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apache-airflow", specifier = ">=2.4" },
+    { name = "apache-airflow", specifier = ">=2.9" },
     { name = "apache-airflow-providers-cncf-kubernetes", marker = "extra == 'all'", specifier = ">=4.4.0" },
     { name = "apache-airflow-providers-cncf-kubernetes", marker = "extra == 'kubernetes'", specifier = ">=4.4.0" },
     { name = "apache-airflow-providers-common-sql", marker = "extra == 'all'", specifier = ">=1.2.0" },


### PR DESCRIPTION
Remove all compatibility shims, version guards, and CI matrix entries for Airflow 2.4–2.8. Minimum supported version is now 2.9.

Why upgrading Airflow version

- Runtime version 10.x (Airflow 2.8) has reached EOL
- Airflow 2.x will reach EOL on 22nd Apr 2026
- Airflow official providers require min version apache-airflow >= 2.11


Changes in RP

 pyproject.toml                                                                                                                                           
  - apache-airflow>=2.4 → >=2.9 (dependencies + constraint-dependencies)                                                                                   
  - Collapsed the three-matrix test setup (py3.10/3.11/3.12 with different Airflow lists) into a single matrix: all three Python versions × ["2.9", "2.10",
   "2.11", "3.0"]
                                                                                                                                                           
  .github/workflows/cicd.yaml                                                                                                                            
  - Both Run-Unit-Tests and Run-Integration-Tests: removed 2.4–2.8 from airflow-version list and dropped all the exclude: blocks (no longer needed since   
  2.9+ supports all three Python versions)                                                                                                                 
   
  dagfactory/dagbuilder.py                                                                                                                                 
  - _init_task_group_callback_param: removed version >= 2.2.0 guard (always true) — just checks for default_args dict now                                
  - Same function: removed the on_skipped_callback skip for < 2.7.0                                                                                        
  - get_dag_params: removed the < 2.7.0 version gate around processing default_args callbacks
  - process_file_with_datasets: removed the is_airflow_version_at_least_2_9 branch — always takes the 2.9+ path now                                        
  - configure_schedule: removed the is_airflow_version_at_least_2_9 variable; elif has_datasets_attr is now unconditional                                  
  - build: dag_display_name is now set unconditionally (was gated on >= 2.9.0)                                                                             
  - make_decorator: removed the dead map_index_template < 2.7.0 raise                                                                                      
                                                                                                                                                           
  tests/utils.py                                                                                                                                           
  - get_http_sensor_path(): removed the < 2.4.0 branch, always returns the providers path                                                                  
                                                                                                                                                           
  tests/test_dagbuilder.py
  - test_build: removed if version >= 2.9.0 guard on dag_display_name assertion                                                                            
  - test_set_callback_exceptions: removed dead < 2.0.0 versioning exception check                                                                          
  - test_make_dag_with_callbacks: simplified sla_miss_callback guard from 2.6.0 < v < 3.1.0 to v < 3.1.0
  - test_make_dag_with_callbacks_default_args: removed < 2.9.0 guard on on_skipped_callback                                                                
  - test_make_dag_with_task_group_callbacks: removed dead < 2.2.0 if/else wrapper                                                                          
  - test_make_dag_with_task_group_callbacks_default_args: removed dead >= 2.3.0 if wrapper                                                                 
  - TestSchedule three skipifs: changed not (2.8.0 < v < 3.0.0) → v >= 3.0.0                                                                               
  - test_dynamic_task_mapping: removed dead < 2.3.0 error path                                                                                             
  - test_replace_expand_string_with_xcom: removed dead < 2.3.0 if/else wrapper                                                                             
                                                                                                                                                           
  tests/test_dagfactory.py                                                                                                                                 
  - Removed test_kubernetes_pod_operator_dag_lt_2_7 entirely; renamed _gte_2_7 → test_kubernetes_pod_operator_dag and dropped its skipif
                                                                                                                                                           
  tests/test_example_dags.py
  - MIN_VER_DAG_FILE_VER: cleared entirely (all entries had min versions ≤ 2.9)                                                                            
  - test_example_dag: removed the >= 2.5 guard on dag.test() — just calls it directly                                                                      
                                                                                                                                                           
  README.md                                                                                                                                                
  - Apache Airflow® 2.4+ → 2.9+        