### PR TITLE
Add airflow 3.1 support

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -64,12 +64,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
         exclude:
-          - python-version: "3.10"
-            airflow-version: "3.1"
-          - python-version: "3.11"
-            airflow-version: "3.1"
-          - python-version: "3.12"
-            airflow-version: "3.1"
           - python-version: "3.13"
             airflow-version: "2.9"
           - python-version: "3.13"
@@ -129,12 +123,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
         exclude:
-          - python-version: "3.10"
-            airflow-version: "3.1"
-          - python-version: "3.11"
-            airflow-version: "3.1"
-          - python-version: "3.12"
-            airflow-version: "3.1"
           - python-version: "3.13"
             airflow-version: "2.9"
           - python-version: "3.13"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,7 +9,7 @@ on:
   # your changes won't run here. you need to temporarily add your branch to
   # the `branches` list above.
   pull_request:
-    branches: [main]
+    branches: [main, add-airflow-3.1-support]
   # run on releases
   release:
     types: ["published"]

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        airflow-version: ["2.9", "2.10", "2.11", "3.0"]
+        airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        airflow-version: ["2.9", "2.10", "2.11", "3.0"]
+        airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -61,8 +61,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
+        exclude:
+          - python-version: "3.10"
+            airflow-version: "3.1"
+          - python-version: "3.11"
+            airflow-version: "3.1"
+          - python-version: "3.12"
+            airflow-version: "3.1"
+          - python-version: "3.13"
+            airflow-version: "2.9"
+          - python-version: "3.13"
+            airflow-version: "2.10"
+          - python-version: "3.13"
+            airflow-version: "2.11"
+          - python-version: "3.13"
+            airflow-version: "3.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -111,8 +126,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1"]
+        exclude:
+          - python-version: "3.10"
+            airflow-version: "3.1"
+          - python-version: "3.11"
+            airflow-version: "3.1"
+          - python-version: "3.12"
+            airflow-version: "3.1"
+          - python-version: "3.13"
+            airflow-version: "2.9"
+          - python-version: "3.13"
+            airflow-version: "2.10"
+          - python-version: "3.13"
+            airflow-version: "2.11"
+          - python-version: "3.13"
+            airflow-version: "3.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,7 +9,7 @@ on:
   # your changes won't run here. you need to temporarily add your branch to
   # the `branches` list above.
   pull_request:
-    branches: [main, add-airflow-3.1-support]
+    branches: [main]
   # run on releases
   release:
     types: ["published"]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -13,7 +13,10 @@ from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from airflow import configuration
+try:
+    from airflow import configuration
+except ImportError:
+    import airflow.configuration as configuration
 from packaging import version
 
 from dagfactory.utils import check_dict_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.10", "3.11", "3.12"]
-airflow = ["2.9", "2.10", "2.11", "3.0"]
+airflow = ["2.9", "2.10", "2.11", "3.0", "3.1"]
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.13"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.10", "3.11", "3.12"]
-airflow = ["2.9", "2.10", "2.11", "3.0"]
+airflow = ["2.9", "2.10", "2.11", "3.0", "3.1"]
 
 
 [tool.hatch.envs.tests.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,11 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.10", "3.11", "3.12"]
-airflow = ["2.9", "2.10", "2.11", "3.0", "3.1"]
+airflow = ["2.9", "2.10", "2.11", "3.0"]
+
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.13"]
+airflow = ["3.1"]
 
 
 [tool.hatch.envs.tests.scripts]

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -34,6 +34,8 @@ uv pip install pip --upgrade
 
 if [ "$AIRFLOW_VERSION" = "3.0" ]; then
   uv pip install "apache-airflow~=3.0.2" "apache-airflow-providers-http>=4.0.0"  "apache-airflow-providers-cncf-kubernetes>=4.4.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack" --constraint /tmp/constraint.txt
+elif [ "$AIRFLOW_VERSION" = "3.1" ]; then
+  uv pip install "apache-airflow~=3.1.0" "apache-airflow-providers-http>=4.0.0"  "apache-airflow-providers-cncf-kubernetes>=4.4.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack" --constraint /tmp/constraint.txt
 else
   uv pip install "apache-airflow==$AIRFLOW_VERSION"  "apache-airflow-providers-http>=4.0.0" "apache-airflow-providers-common-sql>=1.2.0" "apache-airflow-providers-slack"  --constraint /tmp/constraint.txt
   pip install  "apache-airflow==$AIRFLOW_VERSION"  "apache-airflow-providers-cncf-kubernetes>=4.4.0"

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -8,7 +8,6 @@ import pytest
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
-from airflow.utils.state import DagRunState
 from packaging.version import Version
 
 from . import utils as test_utils
@@ -87,7 +86,6 @@ def test_example_dag(session, dag_id: str):
     dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
 
-    dag_run = dag.test()
+    dag_run = test_utils.run_dag(dag)
 
-    if dag_run is not None:
-        assert dag_run.state == DagRunState.SUCCESS
+    assert test_utils.check_dag_success(dag_run)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,9 +65,7 @@ def new_test_dag(dag: DAG) -> DagRun:
 
 
 def run_dag(dag: DAG, conn_file_path: str | None = None) -> DagRun:
-    if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
-        return new_test_dag(dag)
-    return test_old_dag(dag=dag, conn_file_path=conn_file_path)
+    return new_test_dag(dag)
 
 
 @provide_session

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,10 @@ except ImportError:
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.secrets.local_filesystem import LocalFilesystemBackend
-from airflow.utils import timezone
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
@@ -27,14 +30,48 @@ from sqlalchemy.orm.session import Session
 log = logging.getLogger(__name__)
 
 
+def check_dag_success(dag_run: DagRun | None, expect_success: bool = True) -> bool:
+    if dag_run is not None:
+        if expect_success:
+            return dag_run.state == DagRunState.SUCCESS
+        else:
+            return dag_run.state == DagRunState.FAILED
+    return True
+
+
+def new_test_dag(dag: DAG) -> DagRun:
+    if version.parse(AIRFLOW_VERSION) >= version.parse("3.1.0"):
+        # Airflow 3.1+ requires DAG to be serialized to database before calling dag.test()
+        # because create_dagrun() checks for DagVersion and DagModel records
+        from airflow.models.dagbag import DagBag, sync_bag_to_db
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            dag_bundle = DagBundleModel(name="test_bundle")
+            session.merge(dag_bundle)
+            session.commit()
+
+        # collect_dags=False starts an empty bag so bag_dag() won't raise
+        # AirflowDagDuplicatedIdException from DAGs already on disk
+        dagbag = DagBag(collect_dags=False)
+        dagbag.bag_dag(dag)
+        sync_bag_to_db(dagbag, bundle_name="test_bundle", bundle_version="1")
+        return dag.test(logical_date=timezone.utcnow())
+    elif version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
+        return dag.test(logical_date=timezone.utcnow())
+    else:
+        return dag.test()
+
+
 def run_dag(dag: DAG, conn_file_path: str | None = None) -> DagRun:
-    return test_dag(dag=dag, conn_file_path=conn_file_path)
+    if version.parse(AIRFLOW_VERSION) >= version.parse("3.0.0"):
+        return new_test_dag(dag)
+    return test_old_dag(dag=dag, conn_file_path=conn_file_path)
 
 
-# DAG.test() was added in Airflow version 2.5.0. And to test on older Airflow versions, we need to copy the
-# implementation here.
 @provide_session
-def test_dag(
+def test_old_dag(
     dag,
     execution_date: datetime | None = None,
     run_conf: dict[str, Any] | None = None,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,7 @@ def new_test_dag(dag: DAG) -> DagRun:
         return dag.test()
 
 
-def run_dag(dag: DAG, conn_file_path: str | None = None) -> DagRun:
+def run_dag(dag: DAG) -> DagRun:
     return new_test_dag(dag)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,12 +31,12 @@ log = logging.getLogger(__name__)
 
 
 def check_dag_success(dag_run: DagRun | None, expect_success: bool = True) -> bool:
-    if dag_run is not None:
-        if expect_success:
-            return dag_run.state == DagRunState.SUCCESS
-        else:
-            return dag_run.state == DagRunState.FAILED
-    return True
+    if dag_run is None:
+        return False
+    if expect_success:
+        return dag_run.state == DagRunState.SUCCESS
+    else:
+        return dag_run.state == DagRunState.FAILED
 
 
 def new_test_dag(dag: DAG) -> DagRun:


### PR DESCRIPTION
Changes
- Add Python 3.13 to unit and integration test matrices
- Use matrix exclude to pair Airflow 3.1 exclusively with Python 3.13
- Split hatch matrix in pyproject.toml: 3.10-3.12 × 2.9-3.1, and 3.13 × 3.1
- Add "3.1" to airflow-version matrix in unit and integration test jobs
- Add "3.1" to hatch test matrix in pyproject.toml
- Add elif branch in pre-install-airflow.sh to install apache-airflow~=3.1.0
- Wrap `from airflow import configuration` in try/except for 3.1+ compatibility