### PR TITLE
Add Python 3.14 to CI test matrix

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, add-python-3.14-support]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, add-python-3.14-support]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
         exclude:
           - python-version: "3.13"
@@ -72,6 +72,16 @@ jobs:
             airflow-version: "2.11"
           - python-version: "3.13"
             airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "2.9"
+          - python-version: "3.14"
+            airflow-version: "2.10"
+          - python-version: "3.14"
+            airflow-version: "2.11"
+          - python-version: "3.14"
+            airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "3.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -120,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
         exclude:
           - python-version: "3.13"
@@ -131,6 +141,16 @@ jobs:
             airflow-version: "2.11"
           - python-version: "3.13"
             airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "2.9"
+          - python-version: "3.14"
+            airflow-version: "2.10"
+          - python-version: "3.14"
+            airflow-version: "2.11"
+          - python-version: "3.14"
+            airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "3.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: uv-lock
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.3.1
     hooks:
       - id: black
         args: [ "--config", "./pyproject.toml" ]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -318,7 +318,7 @@ class DagBuilder:
         expand_kwargs: Dict[str, Union[Dict[str, Any], Any]] = {}
         if utils.check_dict_key(task_params, "expand") or utils.check_dict_key(task_params, "partial"):
             # Getting expand and partial kwargs from task_params
-            (task_params, expand_kwargs, partial_kwargs) = utils.get_expand_partial_kwargs(task_params)
+            task_params, expand_kwargs, partial_kwargs = utils.get_expand_partial_kwargs(task_params)
 
             # If there are partial_kwargs we should merge them with existing task_params
             if partial_kwargs and not utils.is_partial_duplicated(partial_kwargs, task_params):

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -205,7 +205,7 @@ def check_template_searchpath(template_searchpath: Union[str, List[str]]) -> boo
 
 
 def get_expand_partial_kwargs(
-    task_params: Dict[str, Any]
+    task_params: Dict[str, Any],
 ) -> Tuple[Dict[str, Any], Dict[str, Union[Dict[str, Any], Any]], Dict[str, Union[Dict[str, Any], Any]]]:
     """
     Getting expand and partial kwargs if existed from task_params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "apache-airflow>=2.9",
@@ -116,6 +118,10 @@ airflow = ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
 python = ["3.13"]
 airflow = ["3.1", "3.2"]
 
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.14"]
+airflow = ["3.2"]
+
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
 static-check = " pre-commit run --files dagfactory/* uv.lock"
@@ -174,7 +180,7 @@ build = "mkdocs build --strict"
 
 [tool.black]
 line-length = 120
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 
 [tool.ruff]
 line-length = 120

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -3,7 +3,6 @@
 set -v
 set -x
 set -e
-set -o pipefail
 
 AIRFLOW_VERSION="$1"
 PYTHON_VERSION="$2"

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -3,6 +3,7 @@
 set -v
 set -x
 set -e
+set -o pipefail
 
 AIRFLOW_VERSION="$1"
 PYTHON_VERSION="$2"
@@ -45,9 +46,14 @@ fi;
 
 rm /tmp/constraint.txt
 
-actual_version=$(airflow version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' | head -1)
+actual_version=$(airflow version | grep -oE '^[0-9]+\.[0-9]+' | head -1)
 
-if [ "$actual_version" = $AIRFLOW_VERSION ]; then
+if [ -z "$actual_version" ]; then
+    echo "Failed to determine installed Airflow version"
+    exit 1
+fi
+
+if [ "$actual_version" = "$AIRFLOW_VERSION" ]; then
     echo "Version is as expected: $AIRFLOW_VERSION"
 else
     echo "Version does not match. Expected: $AIRFLOW_VERSION, but got: $actual_version"

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -45,7 +45,7 @@ fi;
 
 rm /tmp/constraint.txt
 
-actual_version=$(airflow version | cut -d. -f1,2)
+actual_version=$(airflow version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' | head -1)
 
 if [ "$actual_version" = $AIRFLOW_VERSION ]; then
     echo "Version is as expected: $AIRFLOW_VERSION"

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1177,7 +1177,7 @@ class TestSchedule:
             ),
             Dataset(uri="s3://dag3/output_3.txt", extra=None),
         )
-        assert schedule_data["schedule"].__eq__(expected)
+        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(
         INSTALLED_AIRFLOW_VERSION >= version.parse("3.0.0"),
@@ -1193,7 +1193,7 @@ class TestSchedule:
             ),
             Dataset(uri="s3://dag3/output_3.txt", extra=None),
         )
-        assert schedule_data["schedule"].__eq__(expected)
+        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_list_of_assets(self):
@@ -1241,7 +1241,7 @@ class TestSchedule:
                 watchers=[],
             ),
         )
-        assert schedule_data["schedule"].__eq__(expected)
+        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_or_operator(self):
@@ -1265,7 +1265,7 @@ class TestSchedule:
                 watchers=[],
             ),
         )
-        assert schedule_data["schedule"].__eq__(expected)
+        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_nested_operators(self):
@@ -1298,7 +1298,7 @@ class TestSchedule:
                 watchers=[],
             ),
         )
-        assert schedule_data["schedule"].__eq__(expected)
+        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_watcher(self):
@@ -1307,21 +1307,19 @@ class TestSchedule:
 
         schedule_data = load_yaml_file(str(schedule_path / "asset_with_watcher.yml"))
 
-        expected = [
-            Asset(
-                name="s3://dag1/output_1.txt",
-                uri="s3://dag1/output_1.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[
-                    AssetWatcher(
-                        name="test_asset_watcher",
-                        trigger=FileDeleteTrigger(filepath="/temp/file.txt", poke_interval=5.0),
-                    )
-                ],
-            )
-        ]
-        assert schedule_data["schedule"].__eq__(expected)
+        expected = Asset(
+            name="s3://dag1/output_1.txt",
+            uri="s3://dag1/output_1.txt",
+            group="asset",
+            extra={"hi": "bye"},
+            watchers=[
+                AssetWatcher(
+                    name="test_asset_watcher",
+                    trigger=FileDeleteTrigger(filepath="/temp/file.txt", poke_interval=5.0),
+                )
+            ],
+        )
+        assert schedule_data["schedule"] == expected
 
     def test_resolve_schedule_cron_string(self):
         yaml_str = "schedule: '* * * * *'"

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1168,15 +1168,13 @@ class TestSchedule:
         reason="Requires Airflow < 3.0.0",
     )
     def test_asset_schedule_list_of_dataset_object(self):
-        from airflow.datasets import Dataset, DatasetAll, DatasetAny
+        from airflow.datasets import Dataset
 
         schedule_data = load_yaml_file(str(schedule_path / "dataset_object_as_list.yml"))
-        expected = DatasetAny(
-            DatasetAll(
-                Dataset(uri="s3://dag1/output_1.txt", extra=None), Dataset(uri="s3://dag2/output_1.txt", extra=None)
-            ),
-            Dataset(uri="s3://dag3/output_3.txt", extra=None),
-        )
+        expected = [
+            Dataset(uri="s3://dag1/output_1.txt", extra=None),
+            Dataset(uri="s3://dag2/output_1.txt", extra=None),
+        ]
         assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(
@@ -1187,13 +1185,12 @@ class TestSchedule:
         from airflow.datasets import Dataset, DatasetAll, DatasetAny
 
         schedule_data = load_yaml_file(str(schedule_path / "nested_dataset.yml"))
-        expected = DatasetAny(
-            DatasetAll(
-                Dataset(uri="s3://dag1/output_1.txt", extra=None), Dataset(uri="s3://dag2/output_1.txt", extra=None)
-            ),
-            Dataset(uri="s3://dag3/output_3.txt", extra=None),
-        )
-        assert schedule_data["schedule"] == expected
+        actual = schedule_data["schedule"]
+        assert isinstance(actual, DatasetAny)
+        assert isinstance(actual.objects[0], DatasetAll)
+        assert actual.objects[0].objects[0] == Dataset(uri="s3://dag1/output_1.txt", extra=None)
+        assert actual.objects[0].objects[1] == Dataset(uri="s3://dag2/output_1.txt", extra=None)
+        assert actual.objects[1] == Dataset(uri="s3://dag3/output_3.txt", extra=None)
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_list_of_assets(self):

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1221,81 +1221,40 @@ class TestSchedule:
         from airflow.sdk import Asset, AssetAll
 
         schedule_data = load_yaml_file(str(schedule_path / "and_asset.yml"))
-
-        expected = AssetAll(
-            Asset(
-                name="s3://dag1/output_1.txt",
-                uri="s3://dag1/output_1.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[],
-            ),
-            Asset(
-                name="s3://dag2/output_1.txt",
-                uri="s3://dag2/output_1.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[],
-            ),
-        )
-        assert schedule_data["schedule"] == expected
+        actual = schedule_data["schedule"]
+        assert isinstance(actual, AssetAll)
+        assert list(actual.objects) == [
+            Asset(name="s3://dag1/output_1.txt", uri="s3://dag1/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+            Asset(name="s3://dag2/output_1.txt", uri="s3://dag2/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+        ]
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_or_operator(self):
         from airflow.sdk import Asset, AssetAny
 
         schedule_data = load_yaml_file(str(schedule_path / "or_asset.yml"))
-
-        expected = AssetAny(
-            Asset(
-                name="s3://dag1/output_1.txt",
-                uri="s3://dag1/output_1.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[],
-            ),
-            Asset(
-                name="s3://dag2/output_1.txt",
-                uri="s3://dag2/output_1.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[],
-            ),
-        )
-        assert schedule_data["schedule"] == expected
+        actual = schedule_data["schedule"]
+        assert isinstance(actual, AssetAny)
+        assert list(actual.objects) == [
+            Asset(name="s3://dag1/output_1.txt", uri="s3://dag1/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+            Asset(name="s3://dag2/output_1.txt", uri="s3://dag2/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+        ]
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_nested_operators(self):
         from airflow.sdk import Asset, AssetAll, AssetAny
 
         schedule_data = load_yaml_file(str(schedule_path / "nested_asset.yml"))
-
-        expected = AssetAny(
-            AssetAll(
-                Asset(
-                    name="s3://dag1/output_1.txt",
-                    uri="s3://dag1/output_1.txt",
-                    group="asset",
-                    extra={"hi": "bye"},
-                    watchers=[],
-                ),
-                Asset(
-                    name="s3://dag2/output_1.txt",
-                    uri="s3://dag2/output_1.txt",
-                    group="asset",
-                    extra={"hi": "bye"},
-                    watchers=[],
-                ),
-            ),
-            Asset(
-                name="s3://dag3/output_3.txt",
-                uri="s3://dag3/output_3.txt",
-                group="asset",
-                extra={"hi": "bye"},
-                watchers=[],
-            ),
+        actual = schedule_data["schedule"]
+        assert isinstance(actual, AssetAny)
+        assert isinstance(actual.objects[0], AssetAll)
+        assert list(actual.objects[0].objects) == [
+            Asset(name="s3://dag1/output_1.txt", uri="s3://dag1/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+            Asset(name="s3://dag2/output_1.txt", uri="s3://dag2/output_1.txt", group="asset", extra={"hi": "bye"}, watchers=[]),
+        ]
+        assert actual.objects[1] == Asset(
+            name="s3://dag3/output_3.txt", uri="s3://dag3/output_3.txt", group="asset", extra={"hi": "bye"}, watchers=[]
         )
-        assert schedule_data["schedule"] == expected
 
     @pytest.mark.skipif(INSTALLED_AIRFLOW_VERSION.major < 3, reason="Requires Airflow >= 3.0.0")
     def test_asset_schedule_with_watcher(self):


### PR DESCRIPTION
Python 3.14 is added to unit and integration test matrices with exclusions for all Airflow versions except 3.2. Also adds py313/py314 to Black target-version, removes py39, and adds Python 3.13/3.14 classifiers.

CI: https://github.com/astronomer/dag-factory/actions/runs/24879319499/job/72844490915?pr=731