### PR TITLE
Fix unconditional sla_miss_callback removal warning in Airflow 3.1+

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -156,8 +156,13 @@ class DagBuilder:
             "sla_miss_callback",  # Not applicable at the default_args level
         ]:
             if callback_type == "sla_miss_callback" and version.parse(AIRFLOW_VERSION) >= version.parse("3.1.0"):
-                # sla_miss_callbacks are removed as of 3.1.0
-                logger.warning("The sla_miss_callback has been removed in Airflow 3.1.0.")
+                # sla_miss_callbacks are removed as of 3.1.0; only warn if it was actually configured
+                sla_configured = utils.check_dict_key(dag_params, "sla_miss_callback") or (
+                    utils.check_dict_key(dag_params, "sla_miss_callback_name")
+                    and utils.check_dict_key(dag_params, "sla_miss_callback_file")
+                )
+                if sla_configured:
+                    logger.warning("The sla_miss_callback has been removed in Airflow 3.1.0.")
                 continue
 
             # Here, we are parsing both the DAG-level params and default_args for callbacks. Previously, this was

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -7,7 +7,8 @@ from unittest.mock import mock_open, patch
 
 import pendulum
 import pytest
-
+import logging
+import copy
 from dagfactory._yaml import load_yaml_file
 
 try:
@@ -791,7 +792,7 @@ def test_make_dag_with_callbacks():
     if version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"):
         from airflow.providers.slack.notifications.slack import send_slack_notification
 
-        dag_config_callbacks__with_provider = dict(DAG_CONFIG_CALLBACKS)
+        dag_config_callbacks__with_provider = copy.deepcopy(DAG_CONFIG_CALLBACKS)
         dag_config_callbacks__with_provider["sla_miss_callback"] = {
             "callback": "airflow.providers.slack.notifications.slack.send_slack_notification",
             "slack_conn_id": "slack_conn_id",
@@ -825,9 +826,8 @@ def test_sla_miss_callback_no_warning_when_not_configured(caplog):
     When sla_miss_callback is NOT present in the DAG config and Airflow >= 3.1.0,
     no deprecation warning should be emitted during DAG parsing.
     """
-    import logging
 
-    dag_config_no_sla = dict(DAG_CONFIG_CALLBACKS)
+    dag_config_no_sla = copy.deepcopy(DAG_CONFIG_CALLBACKS)
     dag_config_no_sla.pop("sla_miss_callback", None)
 
     with caplog.at_level(logging.WARNING, logger="dagfactory"):
@@ -851,9 +851,8 @@ def test_sla_miss_callback_warning_when_configured(caplog):
     When sla_miss_callback IS present in the DAG config and Airflow >= 3.1.0,
     a warning about its removal should be emitted.
     """
-    import logging
 
-    dag_config_with_sla = dict(DAG_CONFIG_CALLBACKS)
+    dag_config_with_sla = copy.deepcopy(DAG_CONFIG_CALLBACKS)
     dag_config_with_sla["sla_miss_callback"] = f"{__name__}.print_context_callback"
 
     with caplog.at_level(logging.WARNING, logger="dagfactory"):

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -816,6 +816,59 @@ def test_make_dag_with_callbacks():
 
 
 @pytest.mark.callbacks
+@pytest.mark.skipif(
+    version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"),
+    reason="sla_miss_callback removal warning only applies to Airflow 3.1.0+",
+)
+def test_sla_miss_callback_no_warning_when_not_configured(caplog):
+    """
+    When sla_miss_callback is NOT present in the DAG config and Airflow >= 3.1.0,
+    no deprecation warning should be emitted during DAG parsing.
+    """
+    import logging
+
+    dag_config_no_sla = dict(DAG_CONFIG_CALLBACKS)
+    dag_config_no_sla.pop("sla_miss_callback", None)
+
+    with caplog.at_level(logging.WARNING, logger="dagfactory"):
+        td = dagbuilder.DagBuilder("test_dag", dag_config_no_sla, DEFAULT_CONFIG)
+        td.build()
+
+    sla_warnings = [r for r in caplog.records if "sla_miss_callback" in r.message]
+    assert sla_warnings == [], (
+        "Expected no sla_miss_callback warning when sla_miss_callback is not configured, "
+        f"but got: {[r.message for r in sla_warnings]}"
+    )
+
+
+@pytest.mark.callbacks
+@pytest.mark.skipif(
+    version.parse(AIRFLOW_VERSION) < version.parse("3.1.0"),
+    reason="sla_miss_callback removal warning only applies to Airflow 3.1.0+",
+)
+def test_sla_miss_callback_warning_when_configured(caplog):
+    """
+    When sla_miss_callback IS present in the DAG config and Airflow >= 3.1.0,
+    a warning about its removal should be emitted.
+    """
+    import logging
+
+    dag_config_with_sla = dict(DAG_CONFIG_CALLBACKS)
+    dag_config_with_sla["sla_miss_callback"] = f"{__name__}.print_context_callback"
+
+    with caplog.at_level(logging.WARNING, logger="dagfactory"):
+        td = dagbuilder.DagBuilder("test_dag", dag_config_with_sla, DEFAULT_CONFIG)
+        td.build()
+
+    sla_warnings = [r for r in caplog.records if "sla_miss_callback" in r.message]
+    assert len(sla_warnings) == 1, (
+        "Expected exactly one sla_miss_callback warning when sla_miss_callback is configured, "
+        f"but got: {[r.message for r in sla_warnings]}"
+    )
+    assert "removed" in sla_warnings[0].message.lower()
+
+
+@pytest.mark.callbacks
 def test_make_dag_with_callbacks_default_args():
     """
     test_make_dag_with_callbacks_default_args


### PR DESCRIPTION

## Summary

Fixes #728.

When running DAG Factory with Airflow 3.1.0+, the warning `"The sla_miss_callback has been removed in Airflow 3.1.0."` was being logged on **every DAG parse**, even when `sla_miss_callback` was never configured by the user.

**Root cause:** In `dagbuilder.py`, the warning was emitted unconditionally inside the callback-type loop whenever `sla_miss_callback` was iterated — regardless of whether it was present in the DAG config.

**Fix:** The warning is now only emitted if `sla_miss_callback` (or its `_name`/`_file` variant) is actually present in the DAG config. The `continue` that prevents registering the removed callback still fires unconditionally, preserving correct runtime behavior.

## Changes

- `dagfactory/dagbuilder.py` — Guard the warning behind a config presence check
- `tests/test_dagbuilder.py` — Added two tests:
  - `test_sla_miss_callback_no_warning_when_not_configured` — asserts no warning when `sla_miss_callback` is absent
  - `test_sla_miss_callback_warning_when_configured` — asserts exactly one warning when `sla_miss_callback` is present

## Test plan

```bash
python -m pytest tests/test_dagbuilder.py -m callbacks -v
```