### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 
 - Change log info to warning by @pankajastro in [#590](https://github.com/astronomer/dag-factory/pull/590)
-- Unify import_from_string methods by gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
+- Unify import_from_string methods by @gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
 
 ### Fixed
 
 - Fix main branch tests by @tatiana in [#638](https://github.com/astronomer/dag-factory/pull/638)
 - fix: support DatasetAlias in outlets by @AppKiv in [#601](https://github.com/astronomer/dag-factory/pull/601)
-- Import TaskGroup in the Airflow 3 way if available by gyli in [#706](https://github.com/astronomer/dag-factory/pull/706)
+- Import TaskGroup in the Airflow 3 way if available by @gyli in [#706](https://github.com/astronomer/dag-factory/pull/706)
 - Handle removal of airflow.utils.module_loading in Airflow 3.1+ by @pankajastro in [#712](https://github.com/astronomer/dag-factory/pull/712)
 - Fix import for datatset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0a1] - 2026-04-29
+
+### Breaking Changes
+
+- Drop Python 3.9 Support by @pankajastro in [#600](https://github.com/astronomer/dag-factory/pull/600)
+- Drop support for Airflow < 2.9 by @pankajastro in [#711](https://github.com/astronomer/dag-factory/pull/711)
+
+### Added
+
+- Add airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
+- Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)
+
+### Improved
+
+- Change log info to warning by @pankajastro in [#590](https://github.com/astronomer/dag-factory/pull/590)
+- Unify import_from_string methods by gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
+
+### Fixed
+
+- Fix main branch tests by @tatiana in [#638](https://github.com/astronomer/dag-factory/pull/638)
+- fix: support DatasetAlias in outlets by @AppKiv in [#601](https://github.com/astronomer/dag-factory/pull/601)
+- Import TaskGroup in the Airflow 3 way if available by gyli in [#706](https://github.com/astronomer/dag-factory/pull/706)
+- Handle removal of airflow.utils.module_loading in Airflow 3.1+ by @pankajastro in [#712](https://github.com/astronomer/dag-factory/pull/712)
+- Fix import for datatset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
+
+### Docs
+
+- Fix markdown lint issues due to dead links by @viiccwen in [#642](https://github.com/astronomer/dag-factory/pull/642)
+- Update docs copyright year to 2026 by @pankajkoti in [#698](https://github.com/astronomer/dag-factory/pull/698)
+- adding timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
+- Add ``items`` as a reserved keys in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
+
+### Other Changes
+
+- Pin structlog to fix the deploy docs job by @pankajastro in [#608](https://github.com/astronomer/dag-factory/pull/608)
+- Remove structlog pin by @pankajkoti in [#656](https://github.com/astronomer/dag-factory/pull/656)
+- Avoid error we're seeing in PRs from external contributors by @tatiana in [#660](https://github.com/astronomer/dag-factory/pull/660)
+- Replace tags with SHAs and update to latest version by @fbuechel92 in [#663](https://github.com/astronomer/dag-factory/pull/663)
+- Add 7-day cooldown to Dependabot config by @pankajkoti in [#686](https://github.com/astronomer/dag-factory/pull/686)
+- Ignore simple_auth_manager_passwords.json.generated from git by @gyli [#695](https://github.com/astronomer/dag-factory/pull/695)
+- Ignore more editor local settings folder by @gyli [#697](https://github.com/astronomer/dag-factory/pull/697)
+
 ## [1.0.1] - 2025-09-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add user_defined_macros support by @gyli in [#693](https://github.com/astronomer/dag-factory/pull/693)
 - Add airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
 - Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)
 
@@ -29,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: support DatasetAlias in outlets by @AppKiv in [#601](https://github.com/astronomer/dag-factory/pull/601)
 - Import TaskGroup in the Airflow 3 way if available by @gyli in [#706](https://github.com/astronomer/dag-factory/pull/706)
 - Handle removal of airflow.utils.module_loading in Airflow 3.1+ by @pankajastro in [#712](https://github.com/astronomer/dag-factory/pull/712)
-- Fix import for datatset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
+- Fix import for dataset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
+- Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets by @ArusheeVerma in [#737](https://github.com/astronomer/dag-factory/pull/737)
 
 ### Docs
 
@@ -47,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add 7-day cooldown to Dependabot config by @pankajkoti in [#686](https://github.com/astronomer/dag-factory/pull/686)
 - Ignore simple_auth_manager_passwords.json.generated from git by @gyli [#695](https://github.com/astronomer/dag-factory/pull/695)
 - Ignore more editor local settings folder by @gyli [#697](https://github.com/astronomer/dag-factory/pull/697)
+- Add Python 3.14 to CI test matrix by @pankajastro in [#731](https://github.com/astronomer/dag-factory/pull/731/)
+- Add AGENTS.md for AI coding agents by @gyli in [#717](https://github.com/astronomer/dag-factory/pull/717)
 
 ## [1.0.1] - 2025-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add user_defined_macros support by @gyli in [#693](https://github.com/astronomer/dag-factory/pull/693)
 - feat: support key: +{task}[{xcom_key}] use by @yanshil in [#593](https://github.com/astronomer/dag-factory/pull/593)
 - Support dataset timetable by @AppKiv in [#599](https://github.com/astronomer/dag-factory/pull/599)
+- Add support for `.airflowignore` file to exclude specific YAML files by @viiccwen in [#654](https://github.com/astronomer/dag-factory/pull/654)
 - Add airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
 - Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)
 
@@ -56,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore more editor local settings folder by @gyli [#697](https://github.com/astronomer/dag-factory/pull/697)
 - Add Python 3.14 to CI test matrix by @pankajastro in [#731](https://github.com/astronomer/dag-factory/pull/731/)
 - Add AGENTS.md for AI coding agents by @gyli in [#717](https://github.com/astronomer/dag-factory/pull/717)
+- fix: use __file__-relative paths in dev examples for Airflow 3 on Astro Hosted by @pankajastro in [#613](https://github.com/astronomer/dag-factory/pull/613)
 
 ## [1.0.1] - 2025-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add user_defined_macros support by @gyli in [#693](https://github.com/astronomer/dag-factory/pull/693)
+- feat: support key: +{task}[{xcom_key}] use by @yanshil in [#593](https://github.com/astronomer/dag-factory/pull/593)
+- Support dataset timetable by @AppKiv in [#599](https://github.com/astronomer/dag-factory/pull/599)
 - Add airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
 - Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)
 
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change log info to warning by @pankajastro in [#590](https://github.com/astronomer/dag-factory/pull/590)
 - Unify import_from_string methods by @gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
+- Ensure default_args_config_path is fully renamed to defaults_config_path @gyli in [#725](https://github.com/astronomer/dag-factory/pull/725)
 
 ### Fixed
 
@@ -32,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle removal of airflow.utils.module_loading in Airflow 3.1+ by @pankajastro in [#712](https://github.com/astronomer/dag-factory/pull/712)
 - Fix import for dataset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
 - Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets by @ArusheeVerma in [#737](https://github.com/astronomer/dag-factory/pull/737)
+- Fix Consumer-side Asset Scheduling on Airflow 3: Convert URI strings in schedule to Asset by @ArusheeVerma in [#738](https://github.com/astronomer/dag-factory/pull/738)
+- Fix unconditional sla_miss_callback removal warning in Airflow 3.1+ by manipatnam in [#734](https://github.com/astronomer/dag-factory/pull/734)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets by @ArusheeVerma in [#737](https://github.com/astronomer/dag-factory/pull/737)
 - Fix Consumer-side Asset Scheduling on Airflow 3: Convert URI strings in schedule to Asset by @ArusheeVerma in [#738](https://github.com/astronomer/dag-factory/pull/738)
 - Fix unconditional sla_miss_callback removal warning in Airflow 3.1+ by @manipatnam in [#734](https://github.com/astronomer/dag-factory/pull/734)
+- Fix python_callable resolution on Airflow 2 with providers-standard by @pankajkoti in [#736](https://github.com/astronomer/dag-factory/pull/736)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: support key: +{task}[{xcom_key}] use by @yanshil in [#593](https://github.com/astronomer/dag-factory/pull/593)
 - Support dataset timetable by @AppKiv in [#599](https://github.com/astronomer/dag-factory/pull/599)
 - Add support for `.airflowignore` file to exclude specific YAML files by @viiccwen in [#654](https://github.com/astronomer/dag-factory/pull/654)
-- Add airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
+- Add Airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
 - Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0a2] - 2026-05-05
+## [1.1.0] - 2026-05-07
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix markdown lint issues due to dead links by @viiccwen in [#642](https://github.com/astronomer/dag-factory/pull/642)
 - Update docs copyright year to 2026 by @pankajkoti in [#698](https://github.com/astronomer/dag-factory/pull/698)
-- adding timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
+- Add timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
 - Add ``items`` as a reserved key in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
 - docs: align contributor and quick-start docs with current Python/Airflow support by @pankajastro in [#740](https://github.com/astronomer/dag-factory/pull/740)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update docs copyright year to 2026 by @pankajkoti in [#698](https://github.com/astronomer/dag-factory/pull/698)
 - adding timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
 - Add ``items`` as a reserved key in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
+- docs: align contributor and quick-start docs with current Python/Airflow support by @pankajastro in [#740](https://github.com/astronomer/dag-factory/pull/740)
 
 ### Other Changes
 
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Python 3.14 to CI test matrix by @pankajastro in [#731](https://github.com/astronomer/dag-factory/pull/731/)
 - Add AGENTS.md for AI coding agents by @gyli in [#717](https://github.com/astronomer/dag-factory/pull/717)
 - fix: use __file__-relative paths in dev examples for Airflow 3 on Astro Hosted by @pankajastro in [#613](https://github.com/astronomer/dag-factory/pull/613)
+- Fix sys.path for DAG helper modules in Astro bundle environments by @pankajastro in [#739](https://github.com/astronomer/dag-factory/pull/739)
 
 ## [1.0.1] - 2025-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix markdown lint issues due to dead links by @viiccwen in [#642](https://github.com/astronomer/dag-factory/pull/642)
 - Update docs copyright year to 2026 by @pankajkoti in [#698](https://github.com/astronomer/dag-factory/pull/698)
 - adding timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
-- Add ``items`` as a reserved keys in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
+- Add ``items`` as a reserved key in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0a1] - 2026-04-29
+## [1.1.0a2] - 2026-05-05
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change log info to warning by @pankajastro in [#590](https://github.com/astronomer/dag-factory/pull/590)
 - Unify import_from_string methods by @gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
-- Ensure default_args_config_path is fully renamed to defaults_config_path @gyli in [#725](https://github.com/astronomer/dag-factory/pull/725)
+- Ensure default_args_config_path is fully renamed to defaults_config_path by @gyli in [#725](https://github.com/astronomer/dag-factory/pull/725)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix import for dataset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
 - Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets by @ArusheeVerma in [#737](https://github.com/astronomer/dag-factory/pull/737)
 - Fix Consumer-side Asset Scheduling on Airflow 3: Convert URI strings in schedule to Asset by @ArusheeVerma in [#738](https://github.com/astronomer/dag-factory/pull/738)
-- Fix unconditional sla_miss_callback removal warning in Airflow 3.1+ by manipatnam in [#734](https://github.com/astronomer/dag-factory/pull/734)
+- Fix unconditional sla_miss_callback removal warning in Airflow 3.1+ by @manipatnam in [#734](https://github.com/astronomer/dag-factory/pull/734)
 
 ### Docs
 

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -2,7 +2,7 @@
 
 from .dagfactory import load_yaml_dags
 
-__version__ = "1.0.1"
+__version__ = "1.1.0a1"
 __all__ = [
     "load_yaml_dags",
 ]

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -2,7 +2,7 @@
 
 from .dagfactory import load_yaml_dags
 
-__version__ = "1.1.0a2"
+__version__ = "1.1.0"
 __all__ = [
     "load_yaml_dags",
 ]

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -2,7 +2,7 @@
 
 from .dagfactory import load_yaml_dags
 
-__version__ = "1.1.0a1"
+__version__ = "1.1.0a2"
 __all__ = [
     "load_yaml_dags",
 ]


### PR DESCRIPTION
## [1.1.0] - 2026-05-07

### Breaking Changes

- Drop Python 3.9 Support by @pankajastro in [#600](https://github.com/astronomer/dag-factory/pull/600)
- Drop support for Airflow < 2.9 by @pankajastro in [#711](https://github.com/astronomer/dag-factory/pull/711)

### Added

- Add user_defined_macros support by @gyli in [#693](https://github.com/astronomer/dag-factory/pull/693)
- feat: support key: +{task}[{xcom_key}] use by @yanshil in [#593](https://github.com/astronomer/dag-factory/pull/593)
- Support dataset timetable by @AppKiv in [#599](https://github.com/astronomer/dag-factory/pull/599)
- Add support for `.airflowignore` file to exclude specific YAML files by @viiccwen in [#654](https://github.com/astronomer/dag-factory/pull/654)
- Add Airflow 3.1 support by @pankajastro in [#720](https://github.com/astronomer/dag-factory/pull/720)
- Add Airflow 3.2 to CI test matrix by @pankajastro in [#723](https://github.com/astronomer/dag-factory/pull/723)

### Improved

- Change log info to warning by @pankajastro in [#590](https://github.com/astronomer/dag-factory/pull/590)
- Unify import_from_string methods by @gyli in [#694](https://github.com/astronomer/dag-factory/pull/694)
- Ensure default_args_config_path is fully renamed to defaults_config_path by @gyli in [#725](https://github.com/astronomer/dag-factory/pull/725)

### Fixed

- Fix main branch tests by @tatiana in [#638](https://github.com/astronomer/dag-factory/pull/638)
- fix: support DatasetAlias in outlets by @AppKiv in [#601](https://github.com/astronomer/dag-factory/pull/601)
- Import TaskGroup in the Airflow 3 way if available by @gyli in [#706](https://github.com/astronomer/dag-factory/pull/706)
- Handle removal of airflow.utils.module_loading in Airflow 3.1+ by @pankajastro in [#712](https://github.com/astronomer/dag-factory/pull/712)
- Fix import for dataset and MappedOperator by @pankajastro in [#713](https://github.com/astronomer/dag-factory/pull/713)
- Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets by @ArusheeVerma in [#737](https://github.com/astronomer/dag-factory/pull/737)
- Fix Consumer-side Asset Scheduling on Airflow 3: Convert URI strings in schedule to Asset by @ArusheeVerma in [#738](https://github.com/astronomer/dag-factory/pull/738)
- Fix unconditional sla_miss_callback removal warning in Airflow 3.1+ by @manipatnam in [#734](https://github.com/astronomer/dag-factory/pull/734)
- Fix python_callable resolution on Airflow 2 with providers-standard by @pankajkoti in [#736](https://github.com/astronomer/dag-factory/pull/736)

### Docs

- Fix markdown lint issues due to dead links by @viiccwen in [#642](https://github.com/astronomer/dag-factory/pull/642)
- Update docs copyright year to 2026 by @pankajkoti in [#698](https://github.com/astronomer/dag-factory/pull/698)
- Add timezone references by @sri-codes-python in [#701](https://github.com/astronomer/dag-factory/pull/701)
- Add ``items`` as a reserved key in doc by @gyli in [#726](https://github.com/astronomer/dag-factory/pull/726)
- docs: align contributor and quick-start docs with current Python/Airflow support by @pankajastro in [#740](https://github.com/astronomer/dag-factory/pull/740)

### Other Changes

- Pin structlog to fix the deploy docs job by @pankajastro in [#608](https://github.com/astronomer/dag-factory/pull/608)
- Remove structlog pin by @pankajkoti in [#656](https://github.com/astronomer/dag-factory/pull/656)
- Avoid error we're seeing in PRs from external contributors by @tatiana in [#660](https://github.com/astronomer/dag-factory/pull/660)
- Replace tags with SHAs and update to latest version by @fbuechel92 in [#663](https://github.com/astronomer/dag-factory/pull/663)
- Add 7-day cooldown to Dependabot config by @pankajkoti in [#686](https://github.com/astronomer/dag-factory/pull/686)
- Ignore simple_auth_manager_passwords.json.generated from git by @gyli [#695](https://github.com/astronomer/dag-factory/pull/695)
- Ignore more editor local settings folder by @gyli [#697](https://github.com/astronomer/dag-factory/pull/697)
- Add Python 3.14 to CI test matrix by @pankajastro in [#731](https://github.com/astronomer/dag-factory/pull/731/)
- Add AGENTS.md for AI coding agents by @gyli in [#717](https://github.com/astronomer/dag-factory/pull/717)
- fix: use __file__-relative paths in dev examples for Airflow 3 on Astro Hosted by @pankajastro in [#613](https://github.com/astronomer/dag-factory/pull/613)
- Fix sys.path for DAG helper modules in Astro bundle environments by @pankajastro in [#739](https://github.com/astronomer/dag-factory/pull/739)

closes: https://github.com/astronomer/dag-factory/issues/733
closes: https://github.com/astronomer/dag-factory/issues/729