### PR TITLE
Fix python_callable resolution on Airflow 2 with providers-standard

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
+        providers-standard-version: [""]
         exclude:
           - python-version: "3.13"
             airflow-version: "2.9"
@@ -82,11 +83,26 @@ jobs:
             airflow-version: "3.0"
           - python-version: "3.14"
             airflow-version: "3.1"
+        # Regression coverage for issue #679: AF 2.11 + apache-airflow-providers-standard 1.9.1.
+        include:
+          - python-version: "3.12"
+            airflow-version: "2.11"
+            providers-standard-version: "1.9.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+
+      - name: Compute hatch env name
+        id: hatch-env
+        run: |
+          suffix=""
+          if [ -n "${{ matrix.providers-standard-version }}" ]; then
+            suffix="-${{ matrix.providers-standard-version }}"
+          fi
+          echo "name=tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}${suffix}" >> "$GITHUB_OUTPUT"
+          echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -94,7 +110,7 @@ jobs:
             ~/.cache/uv
             ~/.cache/pip
             .local/share/hatch/
-          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
+          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}${{ steps.hatch-env.outputs.suffix }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -109,16 +125,16 @@ jobs:
       - name: Install packages and dependencies
         run: |
           uv pip install  --system "hatch>=1.14.2"
-          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
+          hatch -e ${{ steps.hatch-env.outputs.name }} run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
         run: |
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-cov
+          hatch run ${{ steps.hatch-env.outputs.name }}:test-cov
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
+          name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}${{ steps.hatch-env.outputs.suffix }}
           path: .coverage
           include-hidden-files: true
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main]
+    branches: [main, fix-issue-679-python-callable-airflow2]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -96,12 +96,16 @@ jobs:
 
       - name: Compute hatch env name
         id: hatch-env
+        env:
+          PY_VERSION: ${{ matrix.python-version }}
+          AF_VERSION: ${{ matrix.airflow-version }}
+          PROVIDERS_STANDARD_VERSION: ${{ matrix.providers-standard-version }}
         run: |
           suffix=""
-          if [ -n "${{ matrix.providers-standard-version }}" ]; then
-            suffix="-${{ matrix.providers-standard-version }}"
+          if [ -n "$PROVIDERS_STANDARD_VERSION" ]; then
+            suffix="-$PROVIDERS_STANDARD_VERSION"
           fi
-          echo "name=tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}${suffix}" >> "$GITHUB_OUTPUT"
+          echo "name=tests.py${PY_VERSION}-${AF_VERSION}${suffix}" >> "$GITHUB_OUTPUT"
           echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -123,13 +127,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages and dependencies
+        env:
+          HATCH_ENV_NAME: ${{ steps.hatch-env.outputs.name }}
         run: |
           uv pip install  --system "hatch>=1.14.2"
-          hatch -e ${{ steps.hatch-env.outputs.name }} run pip freeze
+          hatch -e "$HATCH_ENV_NAME" run pip freeze
 
       - name: Test DAG Factory against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
+        env:
+          HATCH_ENV_NAME: ${{ steps.hatch-env.outputs.name }}
         run: |
-          hatch run ${{ steps.hatch-env.outputs.name }}:test-cov
+          hatch run "$HATCH_ENV_NAME:test-cov"
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -63,6 +63,23 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
+        # Third matrix axis: optional pin for apache-airflow-providers-standard.
+        #
+        # Purpose: regression coverage for issue #679. On Airflow 2.x with
+        # `apache-airflow-providers-standard==1.9.1` installed, the core and
+        # providers.standard PythonOperator classes diverge — dagbuilder must
+        # handle both. To exercise that combination in CI we need a job where
+        # providers-standard is pinned to a specific version.
+        #
+        # We run this through the same `Run-Unit-Tests` job, not a dedicated
+        # one — the value flows through to `scripts/test/pre-install-airflow.sh`
+        # (3rd arg) via a Hatch matrix variable of the same name in
+        # pyproject.toml. Empty string here = the base-matrix default; every
+        # base combination runs without an explicit pin so providers-standard
+        # is resolved from Airflow's constraints file as usual. The single
+        # `include:` row below adds one extra Run-Unit-Tests job that pins it
+        # to 1.9.1, giving us the regression coverage without multiplying the
+        # matrix across every Python/Airflow combination.
         providers-standard-version: [""]
         exclude:
           - python-version: "3.13"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI jobs
 on:
   # run on pushes to the default branch
   push:
-    branches: [main, fix-issue-679-python-callable-airflow2]
+    branches: [main]
   # run on pull requests originated from forks based on the `main` branch.
   # note that if you're trying to edit the CI in a pull request,
   # your changes won't run here. you need to temporarily add your branch to

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -65,7 +65,7 @@ try:
     _python_operator_classes.append(_StdPythonOperator)
     _branch_python_operator_classes.append(_StdBranchPythonOperator)
     _python_sensor_classes.append(_StdPythonSensor)
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 try:
@@ -78,7 +78,7 @@ try:
     _python_operator_classes.append(_CorePythonOperator)
     _branch_python_operator_classes.append(_CoreBranchPythonOperator)
     _python_sensor_classes.append(_CorePythonSensor)
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 if not _python_operator_classes:  # pragma: no cover

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -81,7 +81,7 @@ try:
 except ImportError:
     pass
 
-if not _python_operator_classes:
+if not _python_operator_classes:  # pragma: no cover
     raise ImportError(
         "Could not import PythonOperator/BranchPythonOperator/PythonSensor from either "
         "'airflow.providers.standard.operators.python' or 'airflow.operators.python'. "

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -81,6 +81,13 @@ try:
 except ImportError:
     pass
 
+if not _python_operator_classes:
+    raise ImportError(
+        "Could not import PythonOperator/BranchPythonOperator/PythonSensor from either "
+        "'airflow.providers.standard.operators.python' or 'airflow.operators.python'. "
+        "Install apache-airflow (with the standard provider, where applicable)."
+    )
+
 PythonOperator = _python_operator_classes[0]
 BranchPythonOperator = _branch_python_operator_classes[0]
 PythonSensor = _python_sensor_classes[0]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -47,10 +47,16 @@ except ImportError:
     from airflow.utils.module_loading import import_string
 from airflow.version import version as AIRFLOW_VERSION
 
-# On Airflow 2.x with apache-airflow-providers-standard installed, both module paths
-# exist and resolve to *different* classes that aren't related by inheritance, so a
-# single try/except would let issubclass() checks miss whichever path the user's YAML
-# didn't pick. Import both when available and check against the union.
+# On Airflow 2.x with apache-airflow-providers-standard installed, both
+# `airflow.operators.python` and `airflow.providers.standard.operators.python`
+# resolve to *different* classes that aren't related by inheritance, so a single
+# try/except would let issubclass() checks miss whichever path the user's YAML
+# didn't pick. Import both when available so the union (PYTHON_CALLABLE_CLASSES)
+# matches either canonical path.
+#
+# We deliberately keep this as classes (and check via issubclass) rather than a
+# set of dotted paths: users may YAML-reference a subclass of PythonOperator
+# (e.g. a custom wrapper), and python_callable resolution should still apply.
 _python_operator_classes = []
 _branch_python_operator_classes = []
 _python_sensor_classes = []
@@ -83,9 +89,13 @@ except ImportError:  # pragma: no cover
 
 if not _python_operator_classes:  # pragma: no cover
     raise ImportError(
-        "Could not import PythonOperator/BranchPythonOperator/PythonSensor from either "
-        "'airflow.providers.standard.operators.python' or 'airflow.operators.python'. "
-        "Install apache-airflow (with the standard provider, where applicable)."
+        "Could not import PythonOperator/BranchPythonOperator/PythonSensor. "
+        "On Airflow 2 these live under `airflow.operators.python` (built-in); "
+        "on Airflow 3 they live under `airflow.providers.standard.operators.python` "
+        "and require `apache-airflow-providers-standard`, which is a hard dependency "
+        "of `apache-airflow>=3` and is normally pulled in automatically. "
+        "Reaching this branch means the install is broken — reinstall apache-airflow "
+        "(and apache-airflow-providers-standard on Airflow 3)."
     )
 
 PythonOperator = _python_operator_classes[0]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -47,12 +47,44 @@ except ImportError:
     from airflow.utils.module_loading import import_string
 from airflow.version import version as AIRFLOW_VERSION
 
-try:  # Try Airflow 3
-    from airflow.providers.standard.operators.python import BranchPythonOperator, PythonOperator
-    from airflow.providers.standard.sensors.python import PythonSensor
+# On Airflow 2.x with apache-airflow-providers-standard installed, both module paths
+# exist and resolve to *different* classes that aren't related by inheritance, so a
+# single try/except would let issubclass() checks miss whichever path the user's YAML
+# didn't pick. Import both when available and check against the union.
+_python_operator_classes = []
+_branch_python_operator_classes = []
+_python_sensor_classes = []
+
+try:
+    from airflow.providers.standard.operators.python import (
+        BranchPythonOperator as _StdBranchPythonOperator,
+        PythonOperator as _StdPythonOperator,
+    )
+    from airflow.providers.standard.sensors.python import PythonSensor as _StdPythonSensor
+
+    _python_operator_classes.append(_StdPythonOperator)
+    _branch_python_operator_classes.append(_StdBranchPythonOperator)
+    _python_sensor_classes.append(_StdPythonSensor)
 except ImportError:
-    from airflow.operators.python import BranchPythonOperator, PythonOperator
-    from airflow.sensors.python import PythonSensor
+    pass
+
+try:
+    from airflow.operators.python import (
+        BranchPythonOperator as _CoreBranchPythonOperator,
+        PythonOperator as _CorePythonOperator,
+    )
+    from airflow.sensors.python import PythonSensor as _CorePythonSensor
+
+    _python_operator_classes.append(_CorePythonOperator)
+    _branch_python_operator_classes.append(_CoreBranchPythonOperator)
+    _python_sensor_classes.append(_CorePythonSensor)
+except ImportError:
+    pass
+
+PythonOperator = _python_operator_classes[0]
+BranchPythonOperator = _branch_python_operator_classes[0]
+PythonSensor = _python_sensor_classes[0]
+PYTHON_CALLABLE_CLASSES = tuple(_python_operator_classes + _branch_python_operator_classes + _python_sensor_classes)
 
 try:
     from airflow.timetables.assets import AssetOrTimeSchedule
@@ -291,7 +323,7 @@ class DagBuilder:
         # class is a Callable https://stackoverflow.com/a/34578836/3679900
         operator_obj: Callable[..., BaseOperator] = import_string(operator)
         # pylint: disable=too-many-nested-blocks
-        if issubclass(operator_obj, (PythonOperator, BranchPythonOperator, PythonSensor)):
+        if issubclass(operator_obj, PYTHON_CALLABLE_CLASSES):
             if (
                 not task_params.get("python_callable")
                 and not task_params.get("python_callable_name")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ compile-bytecode = true
 dependencies = [
     "dag-factory[tests]"
 ]
-pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
+pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python} {matrix:providers-standard:}"]
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.10", "3.11", "3.12"]
@@ -122,6 +122,14 @@ airflow = ["3.1", "3.2"]
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.14"]
 airflow = ["3.2"]
+
+# Regression coverage for issue #679: on Airflow 2.x with apache-airflow-providers-standard
+# installed, the core and providers.standard PythonOperator classes diverge.
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.12"]
+airflow = ["2.11"]
+providers-standard = ["1.9.1"]
+
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -6,6 +6,7 @@ set -e
 
 AIRFLOW_VERSION="$1"
 PYTHON_VERSION="$2"
+PROVIDERS_STANDARD_VERSION="$3"
 
 # Use this to set the appropriate Python environment in Github Actions,
 # while also not assuming --system when running locally.
@@ -43,6 +44,13 @@ else
 fi;
 
 rm /tmp/constraint.txt
+
+# Optionally pin apache-airflow-providers-standard to reproduce issue #679's environment.
+# Installed without the constraints file so its own dependency on
+# apache-airflow-providers-common-compat>=1.7.1 is honoured.
+if [ -n "$PROVIDERS_STANDARD_VERSION" ]; then
+  uv pip install "apache-airflow-providers-standard==$PROVIDERS_STANDARD_VERSION"
+fi
 
 actual_version=$(airflow version | grep -oE '^[0-9]+\.[0-9]+' | head -1)
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -19,6 +19,10 @@ except ImportError:
 import yaml
 from airflow.providers.common.sql.sensors.sql import SqlSensor
 from airflow.providers.http.sensors.http import HttpSensor
+try:
+    from airflow.sdk.module_loading import import_string
+except ImportError:
+    from airflow.utils.module_loading import import_string
 from airflow.version import version as AIRFLOW_VERSION
 from packaging import version
 
@@ -39,16 +43,12 @@ from tests.utils import (
     read_yml,
 )
 
-try:
-    from airflow.providers.standard.operators.bash import BashOperator
-except ImportError:
-    from airflow.operators.bash import BashOperator
-
-
-try:  # Try Airflow 3
-    from airflow.providers.standard.operators.python import PythonOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator
+# Resolve operator classes through the same module path the YAML helpers point to,
+# so isinstance assertions match the class actually instantiated by make_task. On
+# AF2 with providers-standard installed, the core and providers.standard classes
+# are unrelated — picking the wrong one breaks isinstance checks.
+BashOperator = import_string(get_bash_operator_path())
+PythonOperator = import_string(get_python_operator_path())
 
 
 from dagfactory import dagbuilder
@@ -447,6 +447,53 @@ def test_make_python_operator_with_callable_str():
     assert actual.task_id == "test_task"
     assert callable(actual.python_callable)
     assert isinstance(actual, PythonOperator)
+
+
+# Regression test for issue #679: on Airflow 2.x with apache-airflow-providers-standard
+# installed, `airflow.operators.python.PythonOperator` and
+# `airflow.providers.standard.operators.python.PythonOperator` are different, unrelated
+# classes. dagbuilder must resolve python_callable_name/file regardless of which path the
+# YAML uses.
+def _module_importable(module_path):
+    try:
+        __import__(module_path)
+        return True
+    except ImportError:
+        return False
+
+
+_PYTHON_OPERATOR_PATHS = [
+    pytest.param(
+        "airflow.providers.standard.operators.python.PythonOperator",
+        id="providers-standard",
+        marks=pytest.mark.skipif(
+            not _module_importable("airflow.providers.standard.operators.python"),
+            reason="apache-airflow-providers-standard is not installed",
+        ),
+    ),
+    pytest.param(
+        "airflow.operators.python.PythonOperator",
+        id="core",
+        marks=pytest.mark.skipif(
+            INSTALLED_AIRFLOW_VERSION >= version.parse("3.0.0"),
+            reason="airflow.operators.python was removed in Airflow 3",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("operator_path", _PYTHON_OPERATOR_PATHS)
+def test_python_callable_resolution_both_paths(operator_path):
+    td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
+    task_params = {
+        "task_id": "test_task",
+        "python_callable_name": "print_test",
+        "python_callable_file": os.path.realpath(__file__),
+    }
+    actual = td.make_task(operator_path, task_params)
+    assert callable(actual.python_callable)
+    assert "python_callable_name" not in task_params
+    assert "python_callable_file" not in task_params
 
 
 def test_make_python_operator_missing_param():


### PR DESCRIPTION
## Summary

- Fixes #679: on Airflow 2.x with `apache-airflow-providers-standard` installed, `airflow.operators.python.PythonOperator` and `airflow.providers.standard.operators.python.PythonOperator` are **different, unrelated classes**. The single `try/except` import in `dagbuilder.py` bound only one of them, so the `issubclass` check in `make_task` missed YAMLs that referenced the other module path. The result was `python_callable_name`/`python_callable_file` never being resolved into `python_callable`, producing `airflow.exceptions.AirflowException: missing keyword argument 'python_callable'` at parse time.
- Now imports both module paths when available and checks `issubclass` against the union (`PYTHON_CALLABLE_CLASSES`). Both YAML import paths work regardless of which providers are installed.
- Adds a parametrized regression test that exercises both `airflow.operators.python.PythonOperator` and `airflow.providers.standard.operators.python.PythonOperator`, with skip guards for AF3 (no core path) and providers-standard not installed.
- Adds a dedicated CI matrix row — `py3.12 / af2.11 / providers-standard==1.9.1` — wired into the unit-tests workflow so this exact combination is always covered. Achieved by adding a `providers-standard` Hatch matrix variable, a `{matrix:providers-standard:}` substitution in `pre-install-commands`, an optional 3rd arg in `scripts/test/pre-install-airflow.sh`, and an `include:` row + computed env name in `cicd.yaml`.

## Verification

Reproduced the bug locally on Airflow 2.11.0 + `apache-airflow-providers-standard==1.9.1` + `apache-airflow-providers-common-compat==1.14.3` (the reported environment), confirmed both module paths fail before the fix and succeed after. Ran the existing `tests/test_dagbuilder.py` suite on this exact combo: 67 pass, 5 skip, 0 regressions.

| Scenario | Result |
|---|---|
| YAML uses `airflow.operators.python.PythonOperator`, before fix | `AirflowException: missing keyword argument 'python_callable'` |
| YAML uses `airflow.operators.python.PythonOperator`, after fix | works |
| Regression test, providers-standard installed | both params PASS |
| Regression test, providers-standard absent | `[providers-standard]` SKIPPED, `[core]` PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)