### PR TITLE
Fix Asset-based Scheduling on Airflow 3: Convert URI strings to Asset for inlets/outlets

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -972,23 +972,28 @@ class DagBuilder:
                     task_params[variable["attribute"]] = variable_value
             del task_params["variables_as_arguments"]
 
-        if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):
-            for key in ["inlets", "outlets"]:
-                if utils.check_dict_key(task_params, key):
-                    if utils.check_dict_key(task_params[key], "file") and utils.check_dict_key(
-                        task_params[key], "datasets"
-                    ):
-                        file = task_params[key]["file"]
-                        datasets_filter = task_params[key]["datasets"]
-                        datasets_uri = utils.get_datasets_uri_yaml_file(file, datasets_filter)
+        # Convert URI strings in inlets/outlets into Dataset/Asset objects.
+        # On Airflow 3, the ``Dataset`` symbol imported above resolves to
+        # ``airflow.sdk.definitions.asset.Asset``. Without this conversion,
+        # outlets passed as bare URI strings stay as strings on the task; no
+        # AssetEvent is emitted on task success, so consumer DAGs scheduled on
+        # the corresponding Asset never trigger. See issue #718.
+        for key in ["inlets", "outlets"]:
+            if utils.check_dict_key(task_params, key):
+                if utils.check_dict_key(task_params[key], "file") and utils.check_dict_key(
+                    task_params[key], "datasets"
+                ):
+                    file = task_params[key]["file"]
+                    datasets_filter = task_params[key]["datasets"]
+                    datasets_uri = utils.get_datasets_uri_yaml_file(file, datasets_filter)
 
-                        del task_params[key]["file"]
-                        del task_params[key]["datasets"]
-                    else:
-                        datasets_uri = task_params[key]
+                    del task_params[key]["file"]
+                    del task_params[key]["datasets"]
+                else:
+                    datasets_uri = task_params[key]
 
-                    if key in task_params and datasets_uri:
-                        task_params[key] = [Dataset(uri) if isinstance(uri, str) else uri for uri in datasets_uri]
+                if key in task_params and datasets_uri:
+                    task_params[key] = [Dataset(uri) if isinstance(uri, str) else uri for uri in datasets_uri]
 
     @staticmethod
     def make_decorator(

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1072,9 +1072,6 @@ def test_replace_expand_string_with_xcom():
     assert updated_task_conf_xcomarg["expand"]["key_1"] == XComArg(tasks_dict["task_1"])
 
 
-@pytest.mark.skipif(
-    version.parse(AIRFLOW_VERSION) > version.parse("3.0.0"), reason="Requires Airflow version less than 3.0.0"
-)
 @pytest.mark.parametrize(
     "inlets, outlets, expected_inlets, expected_outlets",
     [


### PR DESCRIPTION
## Summary

`dagbuilder.DagBuilder.adjust_general_task_params` was gating the conversion of bare URI strings in `inlets`/`outlets` to `Dataset`/`Asset` objects to Airflow < 3.0.0 only. On Airflow 3 this caused outlets declared as URI strings (e.g. `outlets: ["s3://bucket/key"]`) to remain as plain strings on the resulting task, so:

- no `AssetEvent` was emitted on task success, and
- consumer DAGs scheduled on the corresponding `Asset` never triggered.

The conversion is also valid on Airflow 3 because the `Dataset` symbol imported in `dagbuilder.py` resolves to `airflow.sdk.definitions.asset.Asset` on Airflow 3 (and to `airflow.datasets.Dataset` on Airflow 2). Removing the version gate makes asset-based scheduling work for DAGs authored via dag-factory YAML on Airflow 3.

## Changes

- `dagfactory/dagbuilder.py`: remove the `if version.parse(AIRFLOW_VERSION) < version.parse("3.0.0"):` gate so the inlets/outlets URI-to-Asset conversion runs on Airflow 3 too. De-indent the body and add an explanatory comment.
- `tests/test_dagbuilder.py`: remove the `@pytest.mark.skipif(... > 3.0.0 ...)` from `test_make_task_inlets_outlets`. With the fix in place, the test passes on Airflow 3 — its assertions use `Dataset` imported from `dagfactory.dagbuilder`, which is already aliased to `airflow.sdk.Asset` on Airflow 3.

## Test plan

- [x] Existing `test_make_task_inlets_outlets` parametrized cases (3 cases) pass on Airflow 2 and on Airflow 3 (previously skipped on AF3).
- [x] Manually validated end-to-end on Airflow 3.2.1: a producer DAG with YAML `outlets: ["s3://producer/example.txt"]` writes a row to the `asset_event` table on success, and a consumer DAG declared with `schedule:` referencing the same Asset is auto-triggered by the scheduler.

**Setup.** Airflow 3.2.1 (official `apache/airflow:3.2.1` image), Postgres 16, LocalExecutor, dag-factory mounted editable into `/opt/airflow/dag-factory` and exposed via `PYTHONPATH`. Two DAGs authored in YAML via dag-factory:

- **Producer** `asset_producer` declares one PythonOperator with `outlets: ["s3://producer/example.txt"]`.
- **Consumer** `asset_consumer` declares `schedule:` referencing an Asset whose URI is `s3://producer/example.txt` (declared with `__type__: airflow.sdk.Asset` — see Note 2 at the bottom).

**Procedure.** With each variant of `dagbuilder.py`, restart the scheduler so the dag-processor reloads the dag-factory module, trigger the producer once, and observe 
(a) the resolved outlets on the task, 
(b) the `asset_event` table, 
(c) whether the consumer DAG auto-triggers within a few seconds.

### Test fixtures used to validate this change

I authored a minimal producer/consumer pair via dag-factory YAML to exercise asset-based scheduling end-to-end on Airflow 3.2.1.

#### `dags/asset_producer.yml` — declares an outlet as a bare URI string

```yaml
default:
  default_args:
    owner: "experiment"
    start_date: "2025-01-01"
  schedule: null
  catchup: false
  tags:
    - "experiment"
    - "asset-producer"

asset_producer:
  description: "Producer DAG: declares an outlet using a bare URI string."
  tasks:
    - task_id: produce
      operator: airflow.providers.standard.operators.bash.BashOperator
      bash_command: "echo 'producer fired at' $(date -u +%FT%TZ)"
      outlets:
        - "file:///tmp/dagfactory_demo_asset"
```

#### `dags/asset_producer.py` — dag-factory loader

```python
"""Loader for asset_producer.yml - registers the producer DAG with Airflow."""

import os
from pathlib import Path

from dagfactory import load_yaml_dags

DAGS_DIR = Path(os.path.dirname(__file__))

load_yaml_dags(
    globals_dict=globals(),
    config_filepath=str(DAGS_DIR / "asset_producer.yml"),
)
```
<img width="2436" height="1688" alt="image" src="https://github.com/user-attachments/assets/e3d36fb2-ac7d-41ab-93a1-cf2fd70fc773" />


#### `dags/asset_consumer.yml` — schedule references the same Asset

```yaml
default:
  default_args:
    owner: "experiment"
    start_date: "2025-01-01"
  catchup: false
  tags:
    - "experiment"
    - "asset-consumer"

asset_consumer:
  description: "Consumer DAG: schedule is a real Asset (built via __type__) pointing at the same URI as the producer's outlet."
  schedule:
    - __type__: airflow.sdk.Asset
      uri: "file:///tmp/dagfactory_demo_asset"
      name: "file:///tmp/dagfactory_demo_asset"  # match what dag-factory produces from a URI-string outlet (URI used as name)
  tasks:
    - task_id: consume
      operator: airflow.providers.standard.operators.bash.BashOperator
      bash_command: "echo 'CONSUMER FIRED at' $(date -u +%FT%TZ)"
```

#### `dags/asset_consumer.py` — dag-factory loader

```python
"""Loader for asset_consumer.yml - registers the consumer DAG with Airflow."""

import os
from pathlib import Path

from dagfactory import load_yaml_dags

DAGS_DIR = Path(os.path.dirname(__file__))

load_yaml_dags(
    globals_dict=globals(),
    config_filepath=str(DAGS_DIR / "asset_consumer.yml"),
)
```
<img width="2436" height="1688" alt="image" src="https://github.com/user-attachments/assets/5fdbb918-8403-4933-ab7c-8caf0c333ddd" />


#### Notes on the fixture choices

- **Producer outlet is a bare URI string** — this is the natural way users write asset outlets in YAML and the case this PR fixes.
- **Consumer schedule uses explicit `__type__: airflow.sdk.Asset`** — a workaround for a *separate* dag-factory bug (consumer-side `schedule:` doesn't convert URI strings to Asset on Airflow 3 either; out of scope here).
- **`name` is set equal to `uri`** — Airflow 3 keys assets by both `name` and `uri`. dag-factory's `Dataset(uri)` constructor (which becomes `Asset(uri)` on AF3) uses the URI string as both, so the consumer fixture must match exactly to avoid `AirflowInactiveAssetInInletOrOutletException` on the producer task.

### Observations

| Signal | BEFORE (gate at line 975 present) | AFTER (gate removed) |
|---|---|---|
| Type of `task.outlets[0]` | `str` (literal `'s3://producer/example.txt'`) | `airflow.sdk.definitions.asset.Asset` |
| Rows in `asset_event` after producer success | **0** | **1** |
| Consumer DAG runs auto-triggered (`run_type=asset_triggered`) | **0** — never starts | **1** — auto-triggered within seconds of producer success |
| `airflow assets list-events --asset-uri s3://producer/example.txt` | empty | one event row attributed to `asset_producer.process` |
| Producer task final state in UI | `success` | `success` (unchanged) |

### Why the conversion is needed on Airflow 3

<img width="1129" height="1924" alt="image" src="https://github.com/user-attachments/assets/95b9aa9c-db7b-4885-8435-8b4276277f1b" />
The `Dataset` symbol imported at the top of `dagfactory/dagbuilder.py` already resolves to `airflow.sdk.definitions.asset.Asset` on Airflow 3, so removing the gate is sufficient — no other changes are needed for the conversion to be correct.

## Pre-commit / lint validation
Per the [contributing guide](https://github.com/astronomer/dag-factory/blob/main/docs/contributing/howto.md#pre-commit-and-linting),
ran the same checks `pre-commit run --all-files` would run, against this PR's diff. Clean.
| Hook (from `.pre-commit-config.yaml`) | Pinned version | Local version run | Result on this PR's diff |
|---|---|---|---|
| `ruff` (`astral-sh/ruff-pre-commit`) | `v0.6.9` | `0.15.12` (newer = stricter) | clean |
| `black` (`psf/black`) | `26.3.1` | `26.3.1` (exact match) | clean |
| `codespell` (`codespell-project/codespell`) | `v2.2.4` | `2.4.2` (newer = stricter) | clean |
| trailing-whitespace, end-of-file-fixer, mixed-line-ending (`pre-commit/pre-commit-hooks`) | `v5.0.0` | n/a (file-content check) | clean |


### Reproduction snippet

```bash
docker compose exec -T postgres psql -U airflow -d airflow -c \
  "SELECT ae.id, ae.source_dag_id, ae.source_task_id, ae.source_run_id,
          a.uri, ae.timestamp
     FROM asset_event ae JOIN asset a ON a.id = ae.asset_id
     WHERE a.uri = 's3://producer/example.txt'
     ORDER BY ae.timestamp DESC;"
```
(Returns 0 rows on `main`, 1 row with this PR applied (after one producer run).

### Notes

1. The unit test `test_make_task_inlets_outlets` in `tests/test_dagbuilder.py` was previously skipped on Airflow 3 (it could not pass with the gate in place). This PR re-enables it. Assertions use `Dataset` imported from `dagfactory.dagbuilder`, which is already aliased to `airflow.sdk.Asset` on AF3.
2. A symmetric bug exists on the *consumer* side: YAML `schedule:` declared as a list of bare URI strings is not converted to `Asset` on Airflow 3. Workaround in the consumer fixture above is to declare schedule entries with explicit `__type__: airflow.sdk.Asset`. Happy to send that fix as a follow-up PR if maintainers prefer; kept out of scope here to keep the diff tightly focused on `adjust_general_task_params`.
