### PR TITLE
Fix Consumer-side Asset Scheduling on Airflow 3: Convert URI strings in schedule to Asset (companion to #737)

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -661,8 +661,31 @@ class DagBuilder:
                 and schedule.strip().lower() == "none"
             ):
                 dag_kwargs[schedule_key] = None
+            elif isinstance(schedule, list):
+                # Convert URI strings into Asset objects on Airflow 3 and normalise
+                # the list (skip None, strip strings, drop empties). Without the
+                # conversion, Airflow 3's _default_timetable validator raises
+                # ValueError if any list element is not a BaseAsset. The ``Dataset``
+                # symbol imported at the top of this module resolves to
+                # ``airflow.sdk.definitions.asset.Asset`` on Airflow 3, so the same
+                # conversion that adjust_general_task_params performs for
+                # outlets/inlets (see #737) is correct here for schedule too.
+                # The normalisation step mirrors the existing AF2 list filter at
+                # lines 619-623 so cross-version behaviour is consistent. See #718.
+                normalized_schedule = []
+                for uri in schedule:
+                    if uri is None:
+                        continue
+                    if isinstance(uri, str):
+                        uri = uri.strip()
+                        if not uri:
+                            continue
+                        normalized_schedule.append(Dataset(uri))
+                    else:
+                        normalized_schedule.append(uri)
+                dag_kwargs[schedule_key] = normalized_schedule
             else:
-                dag_kwargs[schedule_key] = dag_params.get("schedule")
+                dag_kwargs[schedule_key] = schedule
 
     @staticmethod
     def _normalise_tasks_config(tasks_cfg: Any) -> Dict[str, Dict[str, Any]]:

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -1417,6 +1417,85 @@ class TestConfigureSchedule:
 
         assert dag_kwargs["schedule"] == expected_return
 
+    def test_configure_schedule_airflow3_list_of_uri_strings(self, patch_airflow_version):
+        """On Airflow 3, ``schedule`` declared as a list of bare URI strings should be
+        converted to Asset objects.
+
+        Without this conversion, Airflow 3's ``_default_timetable`` validator raises
+        ``ValueError`` at DAG construction time because list elements are not
+        ``BaseAsset`` instances. Mirrors the producer-side fix in PR #737. See #718.
+        """
+        patch_airflow_version(3)
+
+        dag_params = {"schedule": ["s3://bucket/data1.parquet", "s3://bucket/data2.parquet"]}
+        dag_kwargs = {}
+
+        DagBuilder.configure_schedule(dag_params, dag_kwargs)
+
+        expected = [Dataset("s3://bucket/data1.parquet"), Dataset("s3://bucket/data2.parquet")]
+        assert dag_kwargs["schedule"] == expected
+
+    def test_configure_schedule_airflow3_list_mixed_string_and_object(self, patch_airflow_version):
+        """``isinstance(uri, str)`` guard preserves already-typed Asset/Dataset
+        objects, so users can mix bare URIs with explicit ``__type__`` entries
+        (e.g. ``airflow.sdk.AssetAlias``) in the same schedule list.
+
+        Pattern reused from PR #601.
+        """
+        patch_airflow_version(3)
+
+        pre_built = Dataset("s3://bucket/already.parquet")
+        dag_params = {"schedule": ["s3://bucket/raw.parquet", pre_built]}
+        dag_kwargs = {}
+
+        DagBuilder.configure_schedule(dag_params, dag_kwargs)
+
+        expected = [Dataset("s3://bucket/raw.parquet"), pre_built]
+        assert dag_kwargs["schedule"] == expected
+
+    def test_configure_schedule_airflow3_empty_list(self, patch_airflow_version):
+        """An empty schedule list must round-trip as an empty list, not crash."""
+        patch_airflow_version(3)
+
+        dag_params = {"schedule": []}
+        dag_kwargs = {}
+
+        DagBuilder.configure_schedule(dag_params, dag_kwargs)
+
+        assert dag_kwargs["schedule"] == []
+
+    def test_configure_schedule_airflow3_list_normalises_none_and_empty(self, patch_airflow_version):
+        """On Airflow 3, list elements are normalised the same way the AF2 branch
+        normalises them (see ``configure_schedule`` lines 619-623): ``None`` entries
+        are dropped, string entries are ``strip()``-ed, and entries that strip to
+        empty are dropped. Pre-typed Asset/Dataset objects pass through unchanged.
+
+        Mirrors the filter behaviour already present on AF2 so cross-version
+        behaviour is consistent. Suggested by Copilot review on PR #738.
+        """
+        patch_airflow_version(3)
+
+        pre_built = Dataset("s3://bucket/already.parquet")
+        dag_params = {
+            "schedule": [
+                "s3://bucket/data.parquet",  # kept, wrapped in Dataset
+                None,  # dropped
+                "",  # dropped (empty string)
+                "   ",  # dropped (whitespace-only)
+                "  s3://bucket/padded.parquet  ",  # kept, stripped, then wrapped
+                pre_built,  # passes through unchanged
+            ]
+        }
+        dag_kwargs = {}
+
+        DagBuilder.configure_schedule(dag_params, dag_kwargs)
+
+        assert dag_kwargs["schedule"] == [
+            Dataset("s3://bucket/data.parquet"),
+            Dataset("s3://bucket/padded.parquet"),
+            pre_built,
+        ]
+
 
 class TestTopologicalSortTasks:
 


### PR DESCRIPTION
## Summary

Companion to #737. Together, these two PRs restore end-to-end asset-based scheduling for DAGs authored via dag-factory YAML on Airflow 3.

`DagBuilder.configure_schedule`'s Airflow 3 branch passed the `schedule` value through to the DAG constructor unmodified. So a YAML schedule of the form

```yaml
my_consumer_dag:
  schedule:
    - "s3://bucket/data.parquet"
```

…reaches Airflow 3 as a `list[str]`, and Airflow 3's `_default_timetable` validator (in `airflow.sdk.definitions.dag`) raises:

```
ValueError: All elements in 'schedule' should be either assets,
asset references, or asset aliases
```

## Changes

- `dagfactory/dagbuilder.py`: in the Airflow 3 branch of `configure_schedule`, when `schedule` is a list, convert each string element to a `Dataset`. The `Dataset` symbol imported at the top of `dagbuilder.py` already aliases to `airflow.sdk.definitions.asset.Asset` on Airflow 3 (and to `airflow.datasets.Dataset` on Airflow 2), so the conversion is correct on both versions.
- The `isinstance(uri, str)` guard preserves already-typed items (e.g. `airflow.sdk.AssetAlias` entries declared via `__type__`) so mixed lists keep working — same defensive pattern used in #601 and mirrored from #737.
- `tests/test_dagbuilder.py`: three new tests under `TestConfigureSchedule`:
  - `test_configure_schedule_airflow3_list_of_uri_strings` — bare URI list converts to `[Asset, Asset]`
  - `test_configure_schedule_airflow3_list_mixed_string_and_object` — `isinstance` guard preserves pre-built objects
  - `test_configure_schedule_airflow3_empty_list` — empty list round-trips as empty list

## Test plan

- [x] Three new unit tests pass.
- [x] Manually validated end-to-end on Airflow 3.2.1, with **both** this PR and #737 applied:
  - Consumer DAG declared with `schedule: ["file:///tmp/dagfactory_demo_asset"]` (bare URI list) loads cleanly — verified via `airflow dags list`.
  - Triggered the producer DAG (which has `outlets: ["file:///tmp/dagfactory_demo_asset"]`).
  - `asset_event` table records the producer's task success: `id=1, source_dag_id=asset_producer, source_task_id=produce`.
  - Consumer DAG auto-triggered immediately, with run_id prefix `asset_triggered__…` and final state `success`.
- [x] Confirmed without this fix (consumer YAML using bare URI list), the consumer DAG fails parsing on Airflow 3 with the `ValueError` quoted above.

## Detailed testing evidence

### TL;DR comparison

| Signal | BEFORE (without this fix) | AFTER (with this fix) |
|---|---|---|
| Consumer YAML using `schedule: ["file:///tmp/dagfactory_demo_asset"]` | DAG **fails to load** at parse time | DAG loads cleanly |
| Error raised | `ValueError: All elements in 'schedule' should be either assets, asset references, or asset aliases` | None |
| Consumer DAG visible in `airflow dags list` | No (parse error) | Yes |
| Producer task success → AssetEvent emitted (with #737 also applied) | Event emitted but no consumer is subscribed because consumer never loaded | Event emitted, consumer is subscribed |
| Consumer auto-triggered after producer success | No (consumer doesn't exist) | Yes — within ~1 second |

---

### Hypothesis

`configure_schedule`'s Airflow 3 branch passes the `schedule` value to the DAG constructor unmodified. On Airflow 3, the `DAG` class validates schedule lists via `_default_timetable` and raises `ValueError` if any list element is not a `BaseAsset`. Therefore a YAML `schedule: ["s3://..."]` is unloadable on Airflow 3 today.

The fix wraps each string element in `Dataset(...)`, which the conditional import at [`dagfactory/dagbuilder.py:34-37`](https://github.com/astronomer/dag-factory/blob/main/dagfactory/dagbuilder.py#L34-L37) aliases to `airflow.sdk.definitions.asset.Asset` on Airflow 3. The wrapped objects satisfy the `BaseAsset` check.

---

### BEFORE evidence (the failure)

**The validator that rejects bare URI strings on Airflow 3** — [`apache/airflow` v3.2.1, `task-sdk/src/airflow/sdk/definitions/dag.py` lines 627-643](https://github.com/apache/airflow/blob/3.2.1/task-sdk/src/airflow/sdk/definitions/dag.py#L627-L643):

```python
@timetable.default
def _default_timetable(instance: DAG) -> BaseTimetable | CoreTimetable:
    schedule = instance.schedule
    # ...
    if isinstance(schedule, Collection) and not isinstance(schedule, str):
        if not all(isinstance(x, BaseAsset) for x in schedule):
            raise ValueError(
                "All elements in 'schedule' should be either assets, asset references, or asset aliases"
            )
        return AssetTriggeredTimetable(AssetAll(*schedule))
    return _create_timetable(schedule, instance.timezone)
```

**The YAML that triggers it on Airflow 3 without this fix:**

```yaml
asset_consumer:
  description: "Consumer DAG: schedule is a bare URI string list"
  schedule:
    - "file:///tmp/dagfactory_demo_asset"
  tasks:
    - task_id: consume
      operator: airflow.providers.standard.operators.bash.BashOperator
      bash_command: "echo 'CONSUMER FIRED'"
```

**To reproduce the BEFORE failure**: check out `main`, load that YAML through dag-factory on Airflow 3.x, and you'll see (in the dag-processor logs):

```
ValueError: All elements in 'schedule' should be either assets,
asset references, or asset aliases
```

The DAG never appears in `airflow dags list` and consumer-side asset scheduling is fully blocked. The repository's own example [`dev/dags/datasets/example_dag_datasets.yml`](https://github.com/astronomer/dag-factory/blob/main/dev/dags/datasets/example_dag_datasets.yml) uses exactly this `schedule: [...]` form and is currently broken on Airflow 3.

---

### AFTER evidence (validated end-to-end on Airflow 3.2.1)

**Consumer fixture used** 

```yaml
asset_consumer:
  description: "Consumer DAG: schedule is a bare URI string list (testing the Airflow 3 schedule conversion fix)."
  schedule:
    - "file:///tmp/dagfactory_demo_asset"
  tasks:
    - task_id: consume
      operator: airflow.providers.standard.operators.bash.BashOperator
      bash_command: "echo 'CONSUMER FIRED at' $(date -u +%FT%TZ)"
```

**1) Both DAGs load successfully** (`airflow dags list`):

```
dag_id           | fileloc                               | owners     | is_paused
asset_consumer   | /opt/airflow/dags/asset_consumer.py   | experiment | False
asset_producer   | /opt/airflow/dags/asset_producer.py   | experiment | False
```

**2) Producer task emits an `AssetEvent`** (live `asset_event` table after one producer trigger):

```sql
SELECT ae.id, ae.source_dag_id, ae.source_task_id, ae.source_run_id,
       a.uri, a.name, ae.timestamp
  FROM asset_event ae LEFT JOIN asset a ON a.id = ae.asset_id
  ORDER BY ae.timestamp DESC LIMIT 5;
```

Output:

```
 id | source_dag_id  | source_task_id |              source_run_id               |                uri                |               name                |           timestamp
----+----------------+----------------+------------------------------------------+-----------------------------------+-----------------------------------+-------------------------------
  1 | asset_producer | produce        | manual__2026-05-03T18:01:17.905819+00:00 | file:///tmp/dagfactory_demo_asset | file:///tmp/dagfactory_demo_asset | 2026-05-03 18:01:19.298442+00
```

Note `name == uri` — that's exactly what dag-factory's `Dataset(uri)` constructor produces (URI is used as both `name` and `uri` on Airflow 3's `Asset`). The matching `asset` row is what enables the consumer to find this event.

**3) Consumer DAG auto-triggered ~0.7s after producer success** (`airflow dags list-runs asset_consumer`):

```
dag_id         | run_id                                                | state   | start_date                       | end_date
asset_consumer | asset_triggered__2026-05-03T18:01:19.303196+00:00_K24jYRYX | success | 2026-05-03T18:01:19.989371+00:00 | 2026-05-03T18:01:20.882142+00:00
```

The `asset_triggered__` prefix in `run_id` is Airflow 3's marker for runs created by the scheduler in response to an `AssetEvent` — distinguishable from `manual__` (manual triggers) or `scheduled__` (cron-driven). Within ~0.7s of the producer's task succeeding, the scheduler created this run and it completed successfully.


### Unit test evidence

Three new tests added under `TestConfigureSchedule` in [`tests/test_dagbuilder.py`](https://github.com/astronomer/dag-factory/blob/main/tests/test_dagbuilder.py). They use the existing `patch_airflow_version` fixture so they exercise the Airflow 3 code path even when run in an Airflow 2 CI environment.

What each test proves:

- **Test 1 (the core conversion)**: validates the happy path — given a list of bare URI strings, every element is wrapped in `Dataset` (which is `Asset` on Airflow 3 via the conditional import). This is the case that fixes the `ValueError`.
- **Test 2 (the guard)**: validates the `isinstance(uri, str)` defensive check — pre-built `Dataset`/`Asset` objects in the list pass through unchanged, so users mixing bare URIs with explicit `__type__: airflow.sdk.AssetAlias` entries don't get a double-wrap or a crash. Same defensive pattern PR #601 introduced for outlets.
- **Test 3 (the empty list)**: validates the boundary condition — an empty schedule list produces an empty list, doesn't crash on iteration.

## Pre-commit / lint validation
Per the [contributing guide](https://github.com/astronomer/dag-factory/blob/main/docs/contributing/howto.md#pre-commit-and-linting),
ran the same checks `pre-commit run --all-files` would run, against this PR's diff. All clean.
| Hook (from `.pre-commit-config.yaml`) | Pinned version | Local version run | Result on this PR's diff |
|---|---|---|---|
| `ruff` (`astral-sh/ruff-pre-commit`) | `v0.6.9` | `0.15.12` (newer = stricter) | clean |
| `black` (`psf/black`) | `26.3.1` | `26.3.1` (exact match) | clean |
| `codespell` (`codespell-project/codespell`) | `v2.2.4` | `2.4.2` (newer = stricter) | clean |
| trailing-whitespace, end-of-file-fixer, mixed-line-ending (`pre-commit/pre-commit-hooks`) | `v5.0.0` | n/a (file-content check) | clean |


## Related

- Fixes the consumer half of issue #718.
- Sibling PR: #737 (producer-side outlets).
- Reuses the defensive pattern from #601.