### PR TITLE
Fix sys.path for DAG helper modules in Astro bundle environments

### DIFF
--- a/dev/dags/comparison/example_hackernews_plain_airflow.py
+++ b/dev/dags/comparison/example_hackernews_plain_airflow.py
@@ -1,8 +1,10 @@
 import sys
 from pathlib import Path
 
-# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Astro DAG bundles deploy to a timestamped path not in sys.path; add parent dags dir so helper modules are importable.
+dags_parent = str(Path(__file__).resolve().parent.parent)
+if dags_parent not in sys.path:
+    sys.path.append(dags_parent)
 
 from datetime import datetime
 

--- a/dev/dags/comparison/example_hackernews_plain_airflow.py
+++ b/dev/dags/comparison/example_hackernews_plain_airflow.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from datetime import datetime
 
 try:

--- a/dev/dags/comparison/example_hackernews_plain_airflow.py
+++ b/dev/dags/comparison/example_hackernews_plain_airflow.py
@@ -1,10 +1,10 @@
 import sys
 from pathlib import Path
 
-# Astro DAG bundles deploy to a timestamped path not in sys.path; add parent dags dir so helper modules are importable.
-dags_parent = str(Path(__file__).resolve().parent.parent)
-if dags_parent not in sys.path:
-    sys.path.append(dags_parent)
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
+config_root_dir_str = str(Path(__file__).resolve().parent.parent)
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 
 from datetime import datetime
 

--- a/dev/dags/comparison/example_pypi_stats_plain_airflow.py
+++ b/dev/dags/comparison/example_pypi_stats_plain_airflow.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from datetime import datetime
 from typing import Any
 

--- a/dev/dags/comparison/example_pypi_stats_plain_airflow.py
+++ b/dev/dags/comparison/example_pypi_stats_plain_airflow.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Astro DAG bundles deploy to a timestamped path not in sys.path; add parent dags dir so helper modules are importable.
+dags_parent_dir = str(Path(__file__).resolve().parent.parent)
+if dags_parent_dir not in sys.path:
+    sys.path.append(dags_parent_dir)
 
 from datetime import datetime
 from typing import Any

--- a/dev/dags/comparison/example_pypi_stats_plain_airflow.py
+++ b/dev/dags/comparison/example_pypi_stats_plain_airflow.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-# Astro DAG bundles deploy to a timestamped path not in sys.path; add parent dags dir so helper modules are importable.
-dags_parent_dir = str(Path(__file__).resolve().parent.parent)
-if dags_parent_dir not in sys.path:
-    sys.path.append(dags_parent_dir)
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert parent dags dir so helper modules are importable.
+config_root_dir_str = str(Path(__file__).resolve().parent.parent)
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 
 from datetime import datetime
 from typing import Any

--- a/dev/dags/example_load_airflow3_dags.py
+++ b/dev/dags/example_load_airflow3_dags.py
@@ -1,8 +1,11 @@
+import sys
 from pathlib import Path
 
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
+sys.path.insert(0, str(CONFIG_ROOT_DIR))
 config_dir = str(CONFIG_ROOT_DIR / "airflow3")
 
 load_yaml_dags(

--- a/dev/dags/example_load_airflow3_dags.py
+++ b/dev/dags/example_load_airflow3_dags.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+config_root_dir_str = str(CONFIG_ROOT_DIR)
 # Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
-sys.path.insert(0, str(CONFIG_ROOT_DIR))
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 config_dir = str(CONFIG_ROOT_DIR / "airflow3")
 
 load_yaml_dags(

--- a/dev/dags/example_load_yaml_dags.py
+++ b/dev/dags/example_load_yaml_dags.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+config_root_dir_str = str(CONFIG_ROOT_DIR)
 # Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
-sys.path.insert(0, str(CONFIG_ROOT_DIR))
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 config_dir = str(CONFIG_ROOT_DIR / "comparison")
 
 load_yaml_dags(

--- a/dev/dags/example_load_yaml_dags.py
+++ b/dev/dags/example_load_yaml_dags.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 # The following import is here so Airflow parses this file
@@ -5,6 +6,8 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
+sys.path.insert(0, str(CONFIG_ROOT_DIR))
 config_dir = str(CONFIG_ROOT_DIR / "comparison")
 
 load_yaml_dags(

--- a/dev/dags/example_map_index_template.py
+++ b/dev/dags/example_map_index_template.py
@@ -7,7 +7,9 @@ from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
 # Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
-sys.path.insert(0, str(CONFIG_ROOT_DIR))
+config_root_dir_str = str(CONFIG_ROOT_DIR)
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 
 config_file = str(CONFIG_ROOT_DIR / "example_map_index_template.yml")
 

--- a/dev/dags/example_map_index_template.py
+++ b/dev/dags/example_map_index_template.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 # The following import is here so Airflow parses this file
@@ -5,6 +6,8 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
+sys.path.insert(0, str(CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_map_index_template.yml")
 

--- a/dev/dags/example_object_storage.py
+++ b/dev/dags/example_object_storage.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 # The following import is here so Airflow parses this file
@@ -5,6 +6,8 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+# Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
+sys.path.insert(0, str(CONFIG_ROOT_DIR))
 
 config_file = str(CONFIG_ROOT_DIR / "example_object_storage.yml")
 

--- a/dev/dags/example_object_storage.py
+++ b/dev/dags/example_object_storage.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
+CONFIG_ROOT_DIR_STR = str(CONFIG_ROOT_DIR)
 # Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
-sys.path.insert(0, str(CONFIG_ROOT_DIR))
+if CONFIG_ROOT_DIR_STR not in sys.path:
+    sys.path.insert(0, CONFIG_ROOT_DIR_STR)
 
 config_file = str(CONFIG_ROOT_DIR / "example_object_storage.yml")
 

--- a/dev/dags/example_object_storage.py
+++ b/dev/dags/example_object_storage.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from dagfactory import load_yaml_dags
 
 CONFIG_ROOT_DIR = Path(__file__).resolve().parent
-CONFIG_ROOT_DIR_STR = str(CONFIG_ROOT_DIR)
+config_root_dir_str = str(CONFIG_ROOT_DIR)
 # Astro DAG bundles deploy to a timestamped path not in sys.path; insert it so helper modules are importable.
-if CONFIG_ROOT_DIR_STR not in sys.path:
-    sys.path.insert(0, CONFIG_ROOT_DIR_STR)
+if config_root_dir_str not in sys.path:
+    sys.path.insert(0, config_root_dir_str)
 
 config_file = str(CONFIG_ROOT_DIR / "example_object_storage.yml")
 


### PR DESCRIPTION
Follow-up: https://github.com/astronomer/dag-factory/pull/613

In Astro Hosted, DAG bundles deploy to a timestamped path (/tmp/airflow/dag_bundles/.../dags/) that is not in sys.path, so helper modules (hacker_news, pypi_stats, sample) are not importable. Each file now inserts its own directory via __file__ so the path resolves correctly regardless of the deployment timestamp.