### PR TITLE
docs: align contributor and quick-start docs with current Python/Airflow support

### DIFF
--- a/docs/contributing/howto.md
+++ b/docs/contributing/howto.md
@@ -31,7 +31,7 @@ To contribute to the DAG Factory project:
 ### Requirements
 
 - [Git](https://git-scm.com/)
-- [Python](https://www.python.org/) <= 3.12 (due to dependencies, such as `google-re2` not supporting Python 3.13 yet)
+- [Python](https://www.python.org/) 3.10–3.14
 - [uv](https://docs.astral.sh/uv/) (for fast package management)
 - [Hatch](https://hatch.pypa.io/latest/) (installed automatically via uv)
 
@@ -146,10 +146,10 @@ The [pyproject. toml](https://github.com/astronomer/dag-factory/blob/main/pyproj
 !!! note
     - These tests create local Python virtual environments in a hatch-managed directory.
 
-To run unit tests using Python 3.10 and Airflow 2.5, use the following:
+To run unit tests using Python 3.10 and Airflow 2.9, use the following:
 
 ```bash
-hatch run tests.py3.10-2.5:test-cov
+hatch run tests.py3.10-2.9:test-cov
 ```
 
 It is also possible to run the tests using all the matrix combinations, by using:

--- a/docs/getting-started/quick-start-astro-cli.md
+++ b/docs/getting-started/quick-start-astro-cli.md
@@ -6,7 +6,7 @@
 
 The minimum requirements for **dag-factory** are:
 
-- Python 3.9.0+
+- Python 3.10.0+
 - [Astro CLI](https://www.astronomer.io/docs/astro/cli/overview/)
 
 ## Step 1: Initialize Airflow Project


### PR DESCRIPTION
The howto referenced an Airflow 2.5 hatch env that no longer exists and capped Python at 3.12 over a stale `google-re2` 3.13 wheel issue; the Astro quick-start still listed Python 3.9. Update them to match the current supported range (Python 3.10–3.14, Airflow 2.9+).