### PR TITLE
feat: add strict_mode flag for per-DAG error isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Added
-
-- Add `AIRFLOW__DAG_FACTORY__STRICT_MODE` (`dag_factory.strict_mode`, default `False`).
-  When enabled, raises `DagFactoryConfigException` for any DAG that fails to build, while still
-  registering all DAGs that built successfully. In folder-scan mode, a broken YAML file no longer
-  prevents other files from loading.
-
-### Internal
-
-- `_DagFactory.build_dags()` now returns `Tuple[Dict[str, DAG], Optional[Tuple[str, Exception]]]`
-  instead of `Dict[str, DAG]`. `_DagFactory` is a private class (underscore-prefixed, not exported
-  from `dagfactory/__init__.py`), so this is not part of the public API, but the change is flagged
-  here for anyone reaching into the private surface. The method also no longer raises on per-DAG
-  failures — failures are logged via `logging.exception` and the first failure is returned in the
-  second tuple element.
-
 ## [1.1.0] - 2026-05-07
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-- `_DagFactory.build_dags()` now returns `Tuple[Dict[str, DAG], List[Tuple[str, Exception]]]`
+- `_DagFactory.build_dags()` now returns `Tuple[Dict[str, DAG], Optional[Tuple[str, Exception]]]`
   instead of `Dict[str, DAG]`. `_DagFactory` is a private class (underscore-prefixed, not exported
   from `dagfactory/__init__.py`), so this is not part of the public API, but the change is flagged
   here for anyone reaching into the private surface. The method also no longer raises on per-DAG
-  failures — failures are returned in the second tuple element and logged via `logging.exception`.
+  failures — failures are logged via `logging.exception` and the first failure is returned in the
+  second tuple element.
 
 ## [1.1.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `AIRFLOW__DAG_FACTORY__STRICT_MODE` (`dag_factory.strict_mode`, default `False`).
+  When enabled, raises `DagFactoryConfigException` for any DAG that fails to build, while still
+  registering all DAGs that built successfully. In folder-scan mode, a broken YAML file no longer
+  prevents other files from loading.
+
+### Internal
+
+- `_DagFactory.build_dags()` now returns `Tuple[Dict[str, DAG], List[Tuple[str, Exception]]]`
+  instead of `Dict[str, DAG]`. `_DagFactory` is a private class (underscore-prefixed, not exported
+  from `dagfactory/__init__.py`), so this is not part of the public API, but the change is flagged
+  here for anyone reaching into the private surface. The method also no longer raises on per-DAG
+  failures — failures are returned in the second tuple element and logged via `logging.exception`.
+
 ## [1.1.0] - 2026-05-07
 
 ### Breaking Changes

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -564,7 +564,7 @@ def load_yaml_dags(
                 if any(file_name.endswith(suf) for suf in suffix):
                     candidate_dag_files.append(root_path / file_name)
 
-        first_strict_error: Optional[Tuple[str, Exception]] = None
+        first_strict_error = None
 
         for config_file_path in candidate_dag_files:
             if _should_ignore_file(config_file_path, dags_folder_path, ignore_patterns):

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -218,12 +218,13 @@ class _DagFactory:
         """
         return self.config.get("default", {})
 
-    def build_dags(self) -> Tuple[Dict[str, DAG], List[Tuple[str, Exception]]]:
+    def build_dags(self) -> Tuple[Dict[str, DAG], Optional[Tuple[str, Exception]]]:
         """Build DAGs using the config file.
 
-        :returns: a tuple of ``(dags, build_errors)``. ``dags`` maps ``dag_id`` to the
-            successfully built :class:`DAG` instances; ``build_errors`` is a list of
-            ``(dag_name, exception)`` tuples for DAGs that failed to build.
+        :returns: a tuple of ``(dags, first_build_error)``. ``dags`` maps ``dag_id`` to the
+            successfully built :class:`DAG` instances; ``first_build_error`` is ``None`` if all
+            DAGs built successfully, otherwise a ``(dag_name, exception)`` tuple for the first
+            DAG that failed. Each individual failure is also logged via :func:`logging.exception`.
         """
         dag_configs: Dict[str, Dict[str, Any]] = self.get_dag_configs()
         global_default_args = self._global_default_args()
@@ -240,7 +241,7 @@ class _DagFactory:
         else:
             dag_level_args = {}
 
-        build_errors: List[Tuple[str, Exception]] = []
+        first_build_error = None
 
         for dag_name, dag_config in dag_configs.items():
             try:
@@ -261,9 +262,10 @@ class _DagFactory:
             except Exception as exc:  # pylint: disable=broad-except
                 config_origin = self.config_file_path or "<config_dict>"
                 logging.exception("Failed to build DAG '%s' from '%s'", dag_name, config_origin)
-                build_errors.append((dag_name, exc))
+                if not first_build_error:
+                    first_build_error = (dag_name, exc)
 
-        return dags, build_errors
+        return dags, first_build_error
 
     # pylint: disable=redefined-builtin
     @staticmethod
@@ -284,11 +286,11 @@ class _DagFactory:
         :param globals: The globals() from the file used to generate DAGs. The dag_id
             must be passed into globals() for Airflow to import
         """
-        dags, build_errors = self.build_dags()
+        dags, first_build_error = self.build_dags()
         self.register_dags(dags, globals)
-        if settings.strict_mode and build_errors:
-            first_name, first_error = build_errors[0]
-            raise DagFactoryConfigException(f"DAG build failed: {first_name}: {first_error}") from first_error
+        if settings.strict_mode and first_build_error:
+            name, exc = first_build_error
+            raise DagFactoryConfigException(f"DAG build failed: {name}: {exc}") from exc
 
 
 def _read_airflowignore(ignore_file: Path) -> List[str]:

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -582,7 +582,7 @@ def load_yaml_dags(
                 factory._generate_dags(globals_dict)
             except Exception as e:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)
-                if settings.strict_mode and first_strict_error is None:
+                if settings.strict_mode and not first_strict_error:
                     first_strict_error = (config_file_abs_path, e)
             else:
                 logging.info("DAG loaded: %s", config_file_path)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -287,7 +287,6 @@ class _DagFactory:
         dags, build_errors = self.build_dags()
         self.register_dags(dags, globals)
         if settings.strict_mode and build_errors:
-            logging.debug("Strict mode collected %d DAG build errors: %s", len(build_errors), build_errors)
             first_name, first_error = build_errors[0]
             raise DagFactoryConfigException(f"DAG build failed: {first_name}: {first_error}") from first_error
 

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -287,10 +287,9 @@ class _DagFactory:
         dags, build_errors = self.build_dags()
         self.register_dags(dags, globals)
         if settings.strict_mode and build_errors:
-            details = "; ".join(f"{name}: {exc}" for name, exc in build_errors)
-            first_error = build_errors[0][1]
-            # Chain first failure as __cause__; remaining failures are in `details` and per-DAG logs.
-            raise DagFactoryConfigException(f"DAG build failed: {details}") from first_error
+            logging.debug("Strict mode collected %d DAG build errors: %s", len(build_errors), build_errors)
+            first_name, first_error = build_errors[0]
+            raise DagFactoryConfigException(f"DAG build failed: {first_name}: {first_error}") from first_error
 
 
 def _read_airflowignore(ignore_file: Path) -> List[str]:
@@ -565,7 +564,7 @@ def load_yaml_dags(
                 if any(file_name.endswith(suf) for suf in suffix):
                     candidate_dag_files.append(root_path / file_name)
 
-        strict_errors: List[Tuple[str, Exception]] = []
+        first_strict_error: Optional[Tuple[str, Exception]] = None
 
         for config_file_path in candidate_dag_files:
             if _should_ignore_file(config_file_path, dags_folder_path, ignore_patterns):
@@ -583,12 +582,11 @@ def load_yaml_dags(
                 factory._generate_dags(globals_dict)
             except Exception as e:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)
-                if settings.strict_mode:
-                    strict_errors.append((config_file_abs_path, e))
+                if settings.strict_mode and first_strict_error is None:
+                    first_strict_error = (config_file_abs_path, e)
             else:
                 logging.info("DAG loaded: %s", config_file_path)
 
-        if strict_errors:
-            details = " | ".join(f"{path}: {exc}" for path, exc in strict_errors)
-            first_exc = strict_errors[0][1]
-            raise DagFactoryConfigException(details) from first_exc
+        if first_strict_error:
+            path, exc = first_strict_error
+            raise DagFactoryConfigException(f"Failed to load dag config from '{path}': {exc}") from exc

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -565,7 +565,7 @@ def load_yaml_dags(
                 if any(file_name.endswith(suf) for suf in suffix):
                     candidate_dag_files.append(root_path / file_name)
 
-        strict_errors: List[DagFactoryConfigException] = []
+        strict_errors: List[Tuple[str, Exception]] = []
 
         for config_file_path in candidate_dag_files:
             if _should_ignore_file(config_file_path, dags_folder_path, ignore_patterns):
@@ -584,11 +584,11 @@ def load_yaml_dags(
             except Exception as e:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)
                 if settings.strict_mode:
-                    wrapped = DagFactoryConfigException(f"Failed to load dag config from '{config_file_abs_path}': {e}")
-                    wrapped.__cause__ = e
-                    strict_errors.append(wrapped)
+                    strict_errors.append((config_file_abs_path, e))
             else:
                 logging.info("DAG loaded: %s", config_file_path)
 
         if strict_errors:
-            raise DagFactoryConfigException(" | ".join(str(e) for e in strict_errors))
+            details = " | ".join(f"{path}: {exc}" for path, exc in strict_errors)
+            first_exc = strict_errors[0][1]
+            raise DagFactoryConfigException(details) from first_exc

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     from airflow.models import DAG
 
+from dagfactory import settings
 from dagfactory._yaml import load_yaml_file
 from dagfactory.constants import DEFAULTS_FILE_NAMES
 from dagfactory.dagbuilder import DagBuilder
@@ -217,8 +218,13 @@ class _DagFactory:
         """
         return self.config.get("default", {})
 
-    def build_dags(self) -> Dict[str, DAG]:
-        """Build DAGs using the config file."""
+    def build_dags(self) -> Tuple[Dict[str, DAG], List[Tuple[str, Exception]]]:
+        """Build DAGs using the config file.
+
+        :returns: a tuple of ``(dags, build_errors)``. ``dags`` maps ``dag_id`` to the
+            successfully built :class:`DAG` instances; ``build_errors`` is a list of
+            ``(dag_name, exception)`` tuples for DAGs that failed to build.
+        """
         dag_configs: Dict[str, Dict[str, Any]] = self.get_dag_configs()
         global_default_args = self._global_default_args()
         default_config: Dict[str, Any] = self.get_default_config()
@@ -234,23 +240,30 @@ class _DagFactory:
         else:
             dag_level_args = {}
 
+        build_errors: List[Tuple[str, Exception]] = []
+
         for dag_name, dag_config in dag_configs.items():
-            # Apply DAG-level default arguments from global_default_args to each dag_config,
-            # this is helpful because some arguments are not supported in default_args.
-            if isinstance(global_default_args, dict):
-                dag_config = {**dag_level_args, **dag_config}
+            try:
+                # Apply DAG-level default arguments from global_default_args to each dag_config,
+                # this is helpful because some arguments are not supported in default_args.
+                if isinstance(global_default_args, dict):
+                    dag_config = {**dag_level_args, **dag_config}
 
-            dag_config["task_groups"] = dag_config.get("task_groups", {})
-            dag_builder: DagBuilder = DagBuilder(
-                dag_name=dag_name,
-                dag_config=dag_config,
-                default_config=default_config,
-                yml_dag=self._serialise_config_md(dag_name, dag_config, default_config),
-            )
-            dag: Dict[str, Union[str, DAG]] = dag_builder.build()
-            dags[dag["dag_id"]]: DAG = dag["dag"]
+                dag_config["task_groups"] = dag_config.get("task_groups", {})
+                dag_builder: DagBuilder = DagBuilder(
+                    dag_name=dag_name,
+                    dag_config=dag_config,
+                    default_config=default_config,
+                    yml_dag=self._serialise_config_md(dag_name, dag_config, default_config),
+                )
+                dag: Dict[str, Union[str, DAG]] = dag_builder.build()
+                dags[dag["dag_id"]]: DAG = dag["dag"]
+            except Exception as exc:  # pylint: disable=broad-except
+                config_origin = self.config_file_path or "<config_dict>"
+                logging.exception("Failed to build DAG '%s' from '%s'", dag_name, config_origin)
+                build_errors.append((dag_name, exc))
 
-        return dags
+        return dags, build_errors
 
     # pylint: disable=redefined-builtin
     @staticmethod
@@ -271,8 +284,13 @@ class _DagFactory:
         :param globals: The globals() from the file used to generate DAGs. The dag_id
             must be passed into globals() for Airflow to import
         """
-        dags: Dict[str, Any] = self.build_dags()
+        dags, build_errors = self.build_dags()
         self.register_dags(dags, globals)
+        if settings.strict_mode and build_errors:
+            details = "; ".join(f"{name}: {exc}" for name, exc in build_errors)
+            first_error = build_errors[0][1]
+            # Chain first failure as __cause__; remaining failures are in `details` and per-DAG logs.
+            raise DagFactoryConfigException(f"DAG build failed: {details}") from first_error
 
 
 def _read_airflowignore(ignore_file: Path) -> List[str]:
@@ -547,6 +565,8 @@ def load_yaml_dags(
                 if any(file_name.endswith(suf) for suf in suffix):
                     candidate_dag_files.append(root_path / file_name)
 
+        strict_errors: List[DagFactoryConfigException] = []
+
         for config_file_path in candidate_dag_files:
             if _should_ignore_file(config_file_path, dags_folder_path, ignore_patterns):
                 logging.debug("Ignoring file %s (matched ignore pattern)", config_file_path)
@@ -561,7 +581,14 @@ def load_yaml_dags(
                     defaults_config_dict=defaults_config_dict,
                 )
                 factory._generate_dags(globals_dict)
-            except Exception:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 logging.exception("Failed to load dag from %s", config_file_path)
+                if settings.strict_mode:
+                    wrapped = DagFactoryConfigException(f"Failed to load dag config from '{config_file_abs_path}': {e}")
+                    wrapped.__cause__ = e
+                    strict_errors.append(wrapped)
             else:
                 logging.info("DAG loaded: %s", config_file_path)
+
+        if strict_errors:
+            raise DagFactoryConfigException(" | ".join(str(e) for e in strict_errors))

--- a/dagfactory/settings.py
+++ b/dagfactory/settings.py
@@ -18,3 +18,4 @@ def convert_to_boolean(value: str | None) -> bool:
 enable_telemetry = conf.getboolean("dag_factory", "enable_telemetry", fallback=True)
 do_not_track = convert_to_boolean(os.getenv("DO_NOT_TRACK"))
 no_analytics = convert_to_boolean(os.getenv("SCARF_NO_ANALYTICS"))
+strict_mode = conf.getboolean("dag_factory", "strict_mode", fallback=False)

--- a/docs/configuration/environment_variables.md
+++ b/docs/configuration/environment_variables.md
@@ -16,3 +16,26 @@ configurations that work seamlessly across various environments.
 In the above example, `$CONFIG_ROOT_DIR` is used to reference an environment variable that points to the root
 directory of your DAG configurations. During DAG parsing, it will be resolved to the value specified for the
 `CONFIG_ROOT_DIR` environment variable.
+
+## Strict Mode
+
+By default DAG Factory silently skips DAGs that fail to build so other DAGs in the same YAML file or folder
+can still be loaded. Setting strict mode raises an exception for every problematic DAG while still registering
+all DAGs that built successfully.
+
+| Variable | Section | Key | Default |
+|---|---|---|---|
+| `AIRFLOW__DAG_FACTORY__STRICT_MODE` | `dag_factory` | `strict_mode` | `False` |
+
+```bash
+AIRFLOW__DAG_FACTORY__STRICT_MODE=true
+```
+
+When strict mode is enabled:
+
+- Each DAG in a YAML file is attempted independently; successfully built DAGs are registered before any
+  exception is raised.
+- If one or more DAGs fail to build, a `DagFactoryConfigException` is raised after registration so Airflow
+  surfaces the error as a broken-DAG import error for that file.
+- In folder-scan mode, each YAML file is still processed independently — a broken file does not prevent other
+  files from loading.

--- a/docs/configuration/environment_variables.md
+++ b/docs/configuration/environment_variables.md
@@ -19,9 +19,9 @@ directory of your DAG configurations. During DAG parsing, it will be resolved to
 
 ## Strict Mode
 
-By default DAG Factory silently skips DAGs that fail to build so other DAGs in the same YAML file or folder
-can still be loaded. Setting strict mode raises an exception for every problematic DAG while still registering
-all DAGs that built successfully.
+By default DAG Factory logs the error and skips DAGs that fail to build so other DAGs in the same YAML file
+or folder can still be loaded. Setting strict mode raises an exception for every problematic DAG while still
+registering all DAGs that built successfully.
 
 | Variable | Section | Key | Default |
 |---|---|---|---|

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -352,12 +352,29 @@ def test_generate_dags_with_removal_valid():
     assert "fake_example_dag" not in globals()
 
 
-def test_generate_dags_invalid():
+def test_generate_dags_invalid_strict(monkeypatch):
+    """In strict mode a broken DAG config raises an exception."""
+    from dagfactory import settings as dag_settings
+
+    monkeypatch.setattr(dag_settings, "strict_mode", True)
     with pytest.raises(Exception):
         load_yaml_dags(
             globals_dict=globals(),
             config_filepath=INVALID_DAG_FACTORY,
         )
+
+
+def test_generate_dags_invalid_non_strict(monkeypatch, caplog):
+    """In non-strict mode a broken DAG config is logged but does not raise."""
+    from dagfactory import settings as dag_settings
+
+    monkeypatch.setattr(dag_settings, "strict_mode", False)
+    with caplog.at_level(logging.ERROR):
+        load_yaml_dags(
+            globals_dict=globals(),
+            config_filepath=INVALID_DAG_FACTORY,
+        )
+    assert any("Failed to build DAG" in r.message for r in caplog.records)
 
 
 def test_kubernetes_pod_operator_dag():
@@ -532,7 +549,7 @@ def test_set_callback_after_loading_config():
 
 
 def test_build_dag_with_global_default():
-    dags = _DagFactory(config_dict=DAG_FACTORY_CONFIG, defaults_config_path=DEFAULT_ARGS_CONFIG_ROOT).build_dags()
+    dags, _ = _DagFactory(config_dict=DAG_FACTORY_CONFIG, defaults_config_path=DEFAULT_ARGS_CONFIG_ROOT).build_dags()
 
     assert dags.get("example_dag").tasks[0].depends_on_past == True
 
@@ -605,7 +622,7 @@ def test_build_dag_with_global_dag_level_defaults():
     td = _DagFactory(config_dict=config)
     with pytest.MonkeyPatch.context() as m:
         m.setattr(td, "_global_default_args", lambda: global_defaults)
-        dags = td.build_dags()
+        dags, _ = td.build_dags()
 
     assert dags["test_dag"].catchup == False
     assert "global_tag" in dags["test_dag"].tags
@@ -616,7 +633,7 @@ def test_build_dag_with_global_dag_level_defaults():
 
 
 def test_build_dag_with_global_default_dict():
-    dags = _DagFactory(
+    dags, _ = _DagFactory(
         config_dict=DAG_FACTORY_CONFIG,
         defaults_config_dict={
             "default_args": {"start_date": "2025-01-01", "owner": "global_owner", "depends_on_past": True}
@@ -678,7 +695,9 @@ def test_load_airflowignore(tmp_path, root_ignore_file_content, nested_ignore_fi
         (nested_dir / ".airflowignore").write_text(nested_ignore_file_content)
 
     ignore_patterns = _load_airflowignore(str(tmp_path))
-    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+    relative_ignore_patterns = {
+        ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()
+    }
     assert relative_ignore_patterns == expected_patterns
 
     loaded_patterns = [pattern for patterns in ignore_patterns.values() for pattern in patterns]
@@ -695,7 +714,9 @@ def test_load_airflowignore_follows_symlinked_directories(tmp_path):
     symlink_dir.symlink_to(external_dir, target_is_directory=True)
 
     ignore_patterns = _load_airflowignore(str(tmp_path))
-    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+    relative_ignore_patterns = {
+        ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()
+    }
 
     assert relative_ignore_patterns == {Path("linked"): ["ignored/*.yml"]}
 
@@ -768,7 +789,9 @@ def test_should_ignore_file(monkeypatch, tmp_path, file_path_str, ignore_pattern
     """Test that _should_ignore_file matches patterns correctly."""
     monkeypatch.setattr(dagfactory, "_get_dag_ignore_file_syntax", lambda: "glob")
     dags_folder = tmp_path
-    ignore_patterns_by_dir = {dags_folder / relative_dir: patterns for relative_dir, patterns in ignore_patterns.items()}
+    ignore_patterns_by_dir = {
+        dags_folder / relative_dir: patterns for relative_dir, patterns in ignore_patterns.items()
+    }
 
     if outside_dags_folder:
         file_path = tmp_path.parent / file_path_str
@@ -840,8 +863,7 @@ def test_should_ignore_file_regexp_ignores_outside_files(monkeypatch, tmp_path):
 def _create_dag_file(file_path: Path, dag_id: str, bash_operator_path: str) -> None:
     """Helper function to create a DAG YAML file"""
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(
-        f"""
+    file_path.write_text(f"""
 default:
   default_args:
     owner: airflow
@@ -852,8 +874,7 @@ default:
     - task_id: task_1
       operator: {bash_operator_path}
       bash_command: echo 1
-"""
-    )
+""")
 
 
 def test_load_yaml_dags_with_airflowignore(monkeypatch, caplog, tmp_path):
@@ -1004,7 +1025,9 @@ def test_load_yaml_dags_prunes_parent_ignored_subtrees(monkeypatch, caplog, tmp_
     (tmp_path / "ignored" / ".airflowignore").write_text("!keep.yml\n")
 
     ignore_patterns = _load_airflowignore(str(tmp_path))
-    relative_ignore_patterns = {ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()}
+    relative_ignore_patterns = {
+        ignore_dir.relative_to(tmp_path): patterns for ignore_dir, patterns in ignore_patterns.items()
+    }
     assert relative_ignore_patterns == {Path("."): ["ignored/"]}
 
     globals_dict = {}
@@ -1204,7 +1227,7 @@ def test_build_dags_timezone_example():
     """DAG-level and default_args timezone keys yield expected aware datetimes (see docs/configuration/defaults.md)."""
     path = os.path.abspath(DAG_FACTORY_TIMEZONE)
     factory = _DagFactory(config_filepath=path)
-    dags = factory.build_dags()
+    dags, _ = factory.build_dags()
     assert set(dags) == {"timezone_dag_level", "timezone_default_args"}
     paris = DateTime(2024, 6, 15, 0, 0, 0, tzinfo=Timezone("Europe/Paris"))
     assert dags["timezone_dag_level"].start_date == paris
@@ -1280,7 +1303,7 @@ def test_default_override_based_on_directory_tree(serialize_config_md_mock, tmp_
 
     some_dag = _DagFactory(str(dag_file), defaults_config_path=str(tmp_path / "a"))
 
-    result = some_dag.build_dags()
+    result, _ = some_dag.build_dags()
     dag = result["second_example_dag"]
     assert dag.default_args["a_param"] == "a"  # accumulates properties define throughout the directories tree
     assert dag.default_args["b_param"] == "b"  # accumulates properties define throughout the directories tree
@@ -1380,3 +1403,138 @@ example_dict_dag_yaml:
     assert len(dag.tasks) == 2
     # Validate grouping
     assert any(task.task_id.startswith("task_group_1.task_2") for task in dag.tasks)
+
+
+# ---------------------------------------------------------------------------
+# Strict mode tests
+# ---------------------------------------------------------------------------
+
+_GOOD_DAG_CONFIG = {
+    "good_dag": {
+        "default_args": {"owner": "airflow", "start_date": "2024-01-01"},
+        "schedule": "0 3 * * *",
+        "tasks": {
+            "task_1": {
+                "operator": get_bash_operator_path(),
+                "bash_command": "echo hello",
+            }
+        },
+    }
+}
+
+_BAD_DAG_CONFIG = {
+    "bad_dag": {
+        "default_args": {"owner": "airflow", "start_date": "2024-01-01"},
+        "schedule": "0 3 * * *",
+        "tasks": {
+            "task_1": {
+                "operator": "non.existent.Operator",
+                "bash_command": "echo hello",
+            }
+        },
+    }
+}
+
+_MIXED_DAG_CONFIG = {**_GOOD_DAG_CONFIG, **_BAD_DAG_CONFIG}
+
+
+def test_build_dags_returns_tuple():
+    """build_dags always returns (dags_dict, errors_list)."""
+    factory = _DagFactory(config_dict=_GOOD_DAG_CONFIG)
+    result = factory.build_dags()
+    assert isinstance(result, tuple) and len(result) == 2
+    dags, errors = result
+    assert "good_dag" in dags
+    assert errors == []
+
+
+def test_build_dags_partial_failure_returns_good_dags():
+    """A broken DAG does not prevent valid ones from being returned."""
+    factory = _DagFactory(config_dict=_MIXED_DAG_CONFIG)
+    dags, errors = factory.build_dags()
+    assert "good_dag" in dags
+    assert len(errors) == 1
+    assert errors[0][0] == "bad_dag"
+    assert isinstance(errors[0][1], Exception)
+
+
+def test_generate_dags_non_strict_swallows_errors():
+    """In non-strict mode, build errors are logged but no exception is raised."""
+    from dagfactory import settings as dag_settings
+
+    factory = _DagFactory(config_dict=_MIXED_DAG_CONFIG)
+    g: dict = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(dag_settings, "strict_mode", False)
+        factory._generate_dags(g)  # must not raise
+
+    assert "good_dag" in g
+
+
+def test_generate_dags_strict_raises_and_registers_good():
+    """In strict mode, good DAGs are registered AND an exception is raised."""
+    from dagfactory import settings as dag_settings
+
+    factory = _DagFactory(config_dict=_MIXED_DAG_CONFIG)
+    g: dict = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(dag_settings, "strict_mode", True)
+        with pytest.raises(Exception, match="DAG build failed"):
+            factory._generate_dags(g)
+
+    assert "good_dag" in g
+
+
+def test_load_yaml_dags_strict_mode_folder_scan_bad_file_raises(tmp_path, monkeypatch):
+    """In folder-scan strict mode a broken YAML file raises after loading good files."""
+    from dagfactory import settings as dag_settings
+
+    good_yaml = tmp_path / "good.yml"
+    good_yaml.write_text(f"""
+good_scan_dag:
+  default_args:
+    owner: airflow
+    start_date: "2024-01-01"
+  schedule: "@daily"
+  tasks:
+    t1:
+      operator: {get_bash_operator_path()}
+      bash_command: echo 1
+""")
+    bad_yaml = tmp_path / "bad.yml"
+    bad_yaml.write_text("not: valid: yaml: [")
+
+    g: dict = {}
+    monkeypatch.setattr(dag_settings, "strict_mode", True)
+    with pytest.raises(Exception):
+        load_yaml_dags(globals_dict=g, dags_folder=str(tmp_path))
+
+    assert "good_scan_dag" in g
+
+
+def test_load_yaml_dags_non_strict_folder_scan_continues_on_error(tmp_path, monkeypatch, caplog):
+    """In non-strict folder-scan mode a broken file is logged but does not prevent other files loading."""
+    from dagfactory import settings as dag_settings
+
+    good_yaml = tmp_path / "good.yml"
+    good_yaml.write_text(f"""
+good_scan_dag2:
+  default_args:
+    owner: airflow
+    start_date: "2024-01-01"
+  schedule: "@daily"
+  tasks:
+    t1:
+      operator: {get_bash_operator_path()}
+      bash_command: echo 1
+""")
+    bad_yaml = tmp_path / "bad.yml"
+    bad_yaml.write_text("not: valid: yaml: [")
+
+    g: dict = {}
+    monkeypatch.setattr(dag_settings, "strict_mode", False)
+    with caplog.at_level(logging.ERROR):
+        load_yaml_dags(globals_dict=g, dags_folder=str(tmp_path))  # must not raise
+
+    assert "good_scan_dag2" in g
+    assert any("bad.yml" in r.message for r in caplog.records)

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -353,11 +353,12 @@ def test_generate_dags_with_removal_valid():
 
 
 def test_generate_dags_invalid_strict(monkeypatch):
-    """In strict mode a broken DAG config raises an exception."""
+    """In strict mode a broken DAG config raises DagFactoryConfigException."""
     from dagfactory import settings as dag_settings
+    from dagfactory.exceptions import DagFactoryConfigException
 
     monkeypatch.setattr(dag_settings, "strict_mode", True)
-    with pytest.raises(Exception):
+    with pytest.raises(DagFactoryConfigException, match="DAG build failed"):
         load_yaml_dags(
             globals_dict=globals(),
             config_filepath=INVALID_DAG_FACTORY,
@@ -1474,12 +1475,13 @@ def test_generate_dags_non_strict_swallows_errors():
 def test_generate_dags_strict_raises_and_registers_good():
     """In strict mode, good DAGs are registered AND an exception is raised."""
     from dagfactory import settings as dag_settings
+    from dagfactory.exceptions import DagFactoryConfigException
 
     factory = _DagFactory(config_dict=_MIXED_DAG_CONFIG)
     g: dict = {}
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(dag_settings, "strict_mode", True)
-        with pytest.raises(Exception, match="DAG build failed"):
+        with pytest.raises(DagFactoryConfigException, match="DAG build failed"):
             factory._generate_dags(g)
 
     assert "good_dag" in g
@@ -1488,6 +1490,7 @@ def test_generate_dags_strict_raises_and_registers_good():
 def test_load_yaml_dags_strict_mode_folder_scan_bad_file_raises(tmp_path, monkeypatch):
     """In folder-scan strict mode a broken YAML file raises after loading good files."""
     from dagfactory import settings as dag_settings
+    from dagfactory.exceptions import DagFactoryConfigException
 
     good_yaml = tmp_path / "good.yml"
     good_yaml.write_text(f"""
@@ -1506,7 +1509,7 @@ good_scan_dag:
 
     g: dict = {}
     monkeypatch.setattr(dag_settings, "strict_mode", True)
-    with pytest.raises(Exception):
+    with pytest.raises(DagFactoryConfigException):
         load_yaml_dags(globals_dict=g, dags_folder=str(tmp_path))
 
     assert "good_scan_dag" in g

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -1440,23 +1440,23 @@ _MIXED_DAG_CONFIG = {**_GOOD_DAG_CONFIG, **_BAD_DAG_CONFIG}
 
 
 def test_build_dags_returns_tuple():
-    """build_dags always returns (dags_dict, errors_list)."""
+    """build_dags always returns (dags_dict, first_build_error)."""
     factory = _DagFactory(config_dict=_GOOD_DAG_CONFIG)
     result = factory.build_dags()
     assert isinstance(result, tuple) and len(result) == 2
-    dags, errors = result
+    dags, first_error = result
     assert "good_dag" in dags
-    assert errors == []
+    assert first_error is None
 
 
 def test_build_dags_partial_failure_returns_good_dags():
     """A broken DAG does not prevent valid ones from being returned."""
     factory = _DagFactory(config_dict=_MIXED_DAG_CONFIG)
-    dags, errors = factory.build_dags()
+    dags, first_error = factory.build_dags()
     assert "good_dag" in dags
-    assert len(errors) == 1
-    assert errors[0][0] == "bad_dag"
-    assert isinstance(errors[0][1], Exception)
+    assert first_error is not None
+    assert first_error[0] == "bad_dag"
+    assert isinstance(first_error[1], Exception)
 
 
 def test_generate_dags_non_strict_swallows_errors():


### PR DESCRIPTION
Re-opened https://github.com/astronomer/dag-factory/pull/719 after messing up with the git history and addressing feedbacks

## Summary

- Introduces `AIRFLOW__DAG_FACTORY__STRICT_MODE` (default: `False`) that, when enabled, raises a `DagFactoryConfigException` for any DAG that fails to build — while still registering all successfully built DAGs.
- `build_dags()` now catches each DAG independently and returns `(dags, build_errors)`, so a single broken DAG in a multi-DAG YAML never prevents the others from loading.
- In folder-scan mode, each YAML file is processed independently — a broken file does not prevent other files from loading.

## Motivation

DAGs silently disappearing from the Airflow UI when a YAML config has a parsing error is hard to debug. Strict mode surfaces these errors as Airflow "Broken DAG" import errors visible in the UI and CI/CD pipelines, while still loading all valid DAGs.