### PR TITLE
feat: support operator_aliases for short operator names in YAML configs

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -281,6 +281,26 @@ class DagBuilder:
         return dag_params
 
     @staticmethod
+    def _resolve_operator_alias(operator: str, operator_aliases: List[Dict[str, str]]) -> str:
+        """
+        Resolves a short operator alias to its full dotted module path.
+
+        If ``operator`` matches an ``operator_alias`` entry in the provided list,
+        the corresponding ``operator_path`` is returned. Otherwise the original
+        string is returned unchanged, allowing full dotted paths to pass through.
+
+        :param operator: the operator string from the task config (alias or full path)
+        :param operator_aliases: list of dicts with ``operator_alias`` and ``operator_path`` keys
+        :returns: resolved full dotted operator path
+        """
+        aliases_map: Dict[str, str] = {
+            entry["operator_alias"]: entry["operator_path"]
+            for entry in operator_aliases
+            if "operator_alias" in entry and "operator_path" in entry
+        }
+        return aliases_map.get(operator, operator)
+
+    @staticmethod
     def _resolve_user_defined_macros(macros: Dict[str, Any], path: str = "user_defined_macros") -> Dict[str, Any]:
         """
         Recursively resolves user_defined_macros values. String values are imported
@@ -974,6 +994,9 @@ class DagBuilder:
 
             if "operator" in task_conf:
                 operator: str = task_conf["operator"]
+                operator = DagBuilder._resolve_operator_alias(
+                    operator, self.default_config.get("operator_aliases", [])
+                )
 
                 if task_conf.get("expand"):
                     task_conf = self.replace_expand_values(task_conf, tasks_dict)

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -233,6 +233,9 @@ class _DagFactory:
             default_config["default_args"] = self._merge_default_args_from_list_configs(
                 [global_default_args, default_config]
             )
+            # Propagate operator_aliases from defaults.yml unless the dag YAML already defines them
+            if "operator_aliases" not in default_config and "operator_aliases" in global_default_args:
+                default_config["operator_aliases"] = global_default_args["operator_aliases"]
 
         dags: Dict[str, Any] = {}
 

--- a/dev/dags/defaults.yml
+++ b/dev/dags/defaults.yml
@@ -4,6 +4,6 @@ default_args:
 
 operator_aliases:
   - operator_alias: BashOperator
-    operator_path: airflow.operators.bash.BashOperator
+    operator_path: airflow.providers.standard.operators.bash.BashOperator
   - operator_alias: PythonOperator
-    operator_path: airflow.operators.python.PythonOperator
+    operator_path: airflow.providers.standard.operators.python.PythonOperator

--- a/dev/dags/defaults.yml
+++ b/dev/dags/defaults.yml
@@ -1,3 +1,9 @@
 default_args:
   start_date: "2025-01-01"
   owner: "global_owner"
+
+operator_aliases:
+  - operator_alias: BashOperator
+    operator_path: airflow.operators.bash.BashOperator
+  - operator_alias: PythonOperator
+    operator_path: airflow.operators.python.PythonOperator

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -400,6 +400,47 @@ def test_make_task_bad_operator():
         td.make_task(operator, task_params)
 
 
+def test_resolve_operator_alias_returns_full_path():
+    aliases = [{"operator_alias": "BashOperator", "operator_path": get_bash_operator_path()}]
+    resolved = DagBuilder._resolve_operator_alias("BashOperator", aliases)
+    assert resolved == get_bash_operator_path()
+
+
+def test_resolve_operator_alias_passthrough_full_path():
+    full_path = get_bash_operator_path()
+    resolved = DagBuilder._resolve_operator_alias(full_path, [])
+    assert resolved == full_path
+
+
+def test_resolve_operator_alias_unknown_alias_passthrough():
+    aliases = [{"operator_alias": "BashOperator", "operator_path": get_bash_operator_path()}]
+    resolved = DagBuilder._resolve_operator_alias("UnknownOperator", aliases)
+    assert resolved == "UnknownOperator"
+
+
+def test_resolve_operator_alias_empty_aliases():
+    resolved = DagBuilder._resolve_operator_alias("BashOperator", [])
+    assert resolved == "BashOperator"
+
+
+def test_build_dag_with_operator_alias():
+    aliases = [{"operator_alias": "BashOperator", "operator_path": get_bash_operator_path()}]
+    default_config_with_aliases = {**DEFAULT_CONFIG, "operator_aliases": aliases}
+    dag_config_with_alias = {
+        **DAG_CONFIG,
+        "tasks": [
+            {
+                "task_id": "task_1",
+                "operator": "BashOperator",
+                "bash_command": "echo 1",
+            }
+        ],
+    }
+    td = dagbuilder.DagBuilder("test_dag", dag_config_with_alias, default_config_with_aliases)
+    result = td.build()
+    assert "task_1" in result["dag"].task_ids
+
+
 def test_make_task_missing_required_param():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
     operator = get_bash_operator_path()

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -633,6 +633,40 @@ def test_build_dag_with_global_dag_level_defaults():
     assert "global_tag" in dags["test_dag_override"].tags
 
 
+def test_build_dags_with_operator_aliases_from_global_defaults():
+    """Test that operator_aliases in global defaults.yml propagate to DagBuilder and resolve correctly."""
+    global_defaults = {
+        "default_args": {
+            "owner": "test_owner",
+            "start_date": "2025-01-01",
+        },
+        "operator_aliases": [
+            {"operator_alias": "BashOperator", "operator_path": get_bash_operator_path()},
+        ],
+    }
+
+    config = {
+        "test_dag": {
+            "tasks": [
+                {
+                    "task_id": "task_1",
+                    "operator": "BashOperator",
+                    "bash_command": "echo 1",
+                }
+            ]
+        }
+    }
+
+    td = _DagFactory(config_dict=config)
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(td, "_global_default_args", lambda: global_defaults)
+        dags, build_error = td.build_dags()
+
+    assert build_error is None
+    assert "task_1" in dags["test_dag"].task_ids
+    assert type(dags["test_dag"].get_task("task_1")).__name__ == "BashOperator"
+
+
 def test_build_dag_with_global_default_dict():
     dags, _ = _DagFactory(
         config_dict=DAG_FACTORY_CONFIG,


### PR DESCRIPTION
## Summary

Closes #58

Adds support for `operator_aliases` in `defaults.yml` (or the `default:` section of a dag YAML), so users can write short operator names instead of full dotted import paths.

**Before:**
```yaml
tasks:
  - task_id: task_1
    operator: airflow.operators.bash.BashOperator
    bash_command: echo 1
```

**After:**
```yaml
# defaults.yml
operator_aliases:
  - operator_alias: BashOperator
    operator_path: airflow.operators.bash.BashOperator

# dag YAML
tasks:
  - task_id: task_1
    operator: BashOperator
    bash_command: echo 1
```

Full dotted paths continue to work unchanged for backward compatibility.

## Changes

- `dagfactory/dagbuilder.py`: added `_resolve_operator_alias()` static method and call it before `make_task()` in `build()`
- `dagfactory/dagfactory.py`: propagate `operator_aliases` from `defaults.yml` into `default_config` so `DagBuilder` can access it
- `dev/dags/defaults.yml`: added example `operator_aliases` entries
- `tests/test_dagbuilder.py`: 5 new tests covering alias resolution, passthrough for full paths, unknown aliases, and end-to-end DAG build with alias

## Test plan

- `test_resolve_operator_alias_returns_full_path`: alias resolves to the correct full path
- `test_resolve_operator_alias_passthrough_full_path`: existing full paths pass through unchanged
- `test_resolve_operator_alias_unknown_alias_passthrough`: unknown alias returns as-is (no error)
- `test_resolve_operator_alias_empty_aliases`: empty alias list is safe
- `test_build_dag_with_operator_alias`: end-to-end, builds a DAG using a short alias name