### PR TITLE
Docs: Add Community section linking to Airflow Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Version **1.0** introduces important improvements and breaking changes to suppor
 
 DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
+##  Community
+
+Join us on the Airflow `Slack <https://apache-airflow.slack.com/archives/C099751BPHT>`_ at #yaml-dags
+
 ## License
 
 To learn more about the terms and conditions for use, reproduction and distribution, read the [Apache License 2.0](https://github.com/astronomer/dag-factory/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduli
 
 ##  Community
 
-Join us on the Airflow `Slack <https://apache-airflow.slack.com/archives/C099751BPHT>`_ at #yaml-dags
+Join us on the Apache Airflow Slack Workspace at [#yaml-dags](https://apache-airflow.slack.com/archives/C099751BPHT)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,10 @@ Version **1.0** introduces important improvements and breaking changes to suppor
 
 DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
+##  Community
+
+Join us on the Airflow `Slack <https://apache-airflow.slack.com/archives/C099751BPHT>`_ at #yaml-dags
+
 ## Getting help
 
 Having trouble? We'd like to help!

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduli
 
 ##  Community
 
-Join us on the Airflow `Slack <https://apache-airflow.slack.com/archives/C099751BPHT>`_ at #yaml-dags
+Join us on the Apache Airflow Slack Workspace at [#yaml-dags](https://apache-airflow.slack.com/archives/C099751BPHT)
 
 ## Getting help
 


### PR DESCRIPTION
## Description

Adds a **Community** section to the README and docs index that points users to the `#yaml-dags` channel in the Apache Airflow Slack workspace.

## Changes
- `README.md` — new Community section
- `docs/index.md` — new Community section

🤖 Generated with [Claude Code](https://claude.com/claude-code)