### PR TITLE
Docs: Bump minimum Airflow version to 2.9 in quick-start guide

### DIFF
--- a/docs/getting-started/quick-start-airflow-standalone.md
+++ b/docs/getting-started/quick-start-airflow-standalone.md
@@ -7,7 +7,7 @@
 The minimum requirements for **dag-factory** are:
 
 - Python 3.10.0+
-- [Apache Airflow®](https://airflow.apache.org) 2.4+
+- [Apache Airflow®](https://airflow.apache.org) 2.9+
 
 ## Step 1: Create a Python Virtual Environment
 


### PR DESCRIPTION
## Description

Updates the minimum supported Apache Airflow version from 2.4+ to 2.9+ in the standalone quick-start guide.

## Changes
- `docs/getting-started/quick-start-airflow-standalone.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)