### PR TITLE
Docs: Document dependency update cooldown policy and add pre-commit cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
       - "@astronomer/oss-integrations"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "@astronomer/oss-integrations"
+    cooldown:
+      default-days: 7

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -1,0 +1,21 @@
+# DAG Factory security
+
+## Security policy
+
+Check the project's [Security Policy](https://github.com/astronomer/dag-factory/blob/main/SECURITY.md) to learn
+how to report security vulnerabilities in DAG Factory and how security issues reported to the Astronomer security
+team are handled.
+
+## Dependency update cooldown
+
+To mitigate the risk of supply chain attacks from newly released versions, DAG Factory enforces a **7-day cooldown
+period** before merging automated dependency update pull requests. This cooldown gives time for the broader community
+to discover and report potential supply chain compromises in new releases before they are adopted into the project.
+
+This policy currently applies to:
+
+- GitHub Actions version updates
+- Pre-commit hook updates
+
+These updates are managed via [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates),
+which is configured with a 7-day cooldown setting for these updates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - contributing/contributors.md
       - contributing/howto.md
       - contributing/roles.md
+      - Security: contributing/security.md
 
 plugins:
   - mike:


### PR DESCRIPTION
## Summary

DAG Factory already enforces a **7-day Dependabot cooldown** for GitHub Actions updates (added in #686), but:

1. The cooldown **policy was not documented** anywhere human-readable — only the machine config in `.github/dependabot.yml` existed.
2. **Pre-commit hook updates were not covered** by any cooldown.

This PR closes both gaps, mirroring how [astronomer-cosmos](https://github.com/astronomer/astronomer-cosmos) already handles this.

## Changes

- **`.github/dependabot.yml`** — add a `pre-commit` ecosystem block with the same `cooldown: default-days: 7` as the existing `github-actions` block, so pre-commit hook bumps are aged before merge.
- **`docs/contributing/security.md`** (new) — a Contributing → Security page documenting the *Dependency update cooldown* policy and its supply-chain-mitigation rationale, plus a link to the security policy. Wired into the mkdocs nav under **Contributing**.

The shared root `SECURITY.md` is intentionally left untouched: it carries the note *"This document is reused across Astronomer OSS Integrations projects"*, and cosmos likewise keeps the cooldown policy in a separate docs page (`docs/policy/security.rst`) rather than in `SECURITY.rst`, so the shared template stays in sync across repos.

## Verification

- `hatch run docs:build` (`mkdocs build --strict`) passes; the new page is picked up by the nav.
- `.github/dependabot.yml` validated as YAML — two ecosystems (`github-actions`, `pre-commit`), both with a 7-day cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)