### PR TITLE
Enable grouped uv version updates with a 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,25 @@ updates:
       - "@astronomer/oss-integrations"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "@astronomer/oss-integrations"
+    cooldown:
+      default-days: 7
+    # Batch routine (minor/patch) Python bumps into a single PR to limit
+    # noise; major bumps still open as individual PRs for careful review.
+    # Security updates are unaffected by cooldown/grouping and continue to
+    # open as soon as an advisory is published.
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Follow-up to #758 (which added 7-day cooldowns for `github-actions` and `pre-commit`).

Today, Python dependencies (managed via `pyproject.toml` + `uv.lock`) only get Dependabot **security updates** — there is no `uv` ecosystem block in `.github/dependabot.yml`, so **routine, non-security version bumps never open** (e.g. #757/#764 were both alert-driven security updates, not routine bumps). This PR enables routine Python updates and applies the same supply-chain safeguards we already use elsewhere.

> [!NOTE]
> This is a deliberate **behavior change**: routine (non-security) Python update PRs will start opening, where previously none did. They are grouped and soaked to keep the volume manageable.

## Changes

Add a `uv` ecosystem block to `.github/dependabot.yml`:

- **`cooldown: default-days: 7`** — routine bumps wait 7 days after release before a PR opens, giving the community time to surface supply-chain issues. Security updates remain exempt (they open immediately, by design).
- **Grouping (`python-minor-and-patch`)** — minor/patch bumps are batched into a single PR to limit noise; **major** bumps still open as individual PRs so potentially breaking changes are reviewed in isolation.

This mirrors the existing `github-actions` and `pre-commit` blocks (same `directory`, `schedule`, `labels`, `reviewers`, `cooldown`).

## Verification

- `.github/dependabot.yml` validated as YAML: three ecosystems (`github-actions`, `pre-commit`, `uv`); the `uv` block carries `cooldown.default-days: 7` and the minor/patch group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)