### PR TITLE
Fix markdown lint violations surfaced by markdownlint-cli 0.48.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ configuration files.
 - Activate the venv: `source .venv/bin/activate` (or `source venv/bin/activate` if you used `make setup`).
 - Install pre-commit hooks once: `pre-commit install`.
 - To run example DAGs locally, export:
-  - `AIRFLOW_HOME=$(pwd)/dev`
-  - `AIRFLOW__CORE__LOAD_EXAMPLES=false`
-  - `CONFIG_ROOT_DIR=$AIRFLOW_HOME/dags`
+    - `AIRFLOW_HOME=$(pwd)/dev`
+    - `AIRFLOW__CORE__LOAD_EXAMPLES=false`
+    - `CONFIG_ROOT_DIR=$AIRFLOW_HOME/dags`
 
 ## Commands
 
@@ -39,7 +39,7 @@ Notes:
 
 ## Repository Structure
 
-```
+```text
 dag-factory/
 ├── dagfactory/         # Library source
 │   ├── dagfactory.py   # Public entry points (load_yaml_dags)
@@ -86,9 +86,9 @@ Vulnerability reports go to `oss_security@astronomer.io` (see `SECURITY.md`). Do
 ## Coding Standards
 
 - Formatting and linting are enforced via `pre-commit`:
-  - `black` and `ruff`, both with `line-length = 120`. Ruff rule selection is `["C901", "D300", "I", "F"]`; isort `known-first-party = ["dagfactory", "tests"]`.
-  - `codespell`, `markdownlint`, `markdown-link-check`, plus checks for large files, merge conflicts, private keys, and AWS credentials.
-  - `uv-lock` keeps `uv.lock` in sync — re-run `uv lock` after editing dependencies.
+    - `black` and `ruff`, both with `line-length = 120`. Ruff rule selection is `["C901", "D300", "I", "F"]`; isort `known-first-party = ["dagfactory", "tests"]`.
+    - `codespell`, `markdownlint`, `markdown-link-check`, plus checks for large files, merge conflicts, private keys, and AWS credentials.
+    - `uv-lock` keeps `uv.lock` in sync — re-run `uv lock` after editing dependencies.
 - All source files are Apache-2.0 licensed (see `LICENSE`); don't add files under a different license without maintainer sign-off.
 - Raise library-specific exceptions from `dagfactory/exceptions.py` (e.g. `DagFactoryException`, `DagFactoryConfigException`) rather than bare `Exception` or generic `RuntimeError`.
 - Public API is whatever `dagfactory/__init__.py` re-exports (`__all__`). Treat it as a contract — additions are fine, renames/removals need a deprecation cycle and a `CHANGELOG.md` entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,12 +325,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support using envvar in config YAML by @tatiana in #236
-- **Callback improvements**
+- __Callback improvements__
   - Support installed code via python callable string by @john-drews in #221
   - Add `callback_file` & `callback_name` to `default_args` DAG level by @subbota19 in #218
   - Cast callbacks to functions when set with `default_args` on TaskGroups by @Baraldo and @pankajastro in #235
 
-- **Telemetry**
+- __Telemetry__
   - For more information, please, read the [Privacy Notice](https://github.com/astronomer/dag-factory/blob/main/PRIVACY_NOTICE.md#collection-of-data).
   - Add scarf to readme for website analytics by @cmarteepants in #219
   - Support telemetry during DAG parsing emitting data to Scarf by @tatiana in #250.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Version **1.0** introduces important improvements and breaking changes to suppor
 
 DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
-##  Community
+## Community
 
 Join us on the Apache Airflow Slack Workspace at [#yaml-dags](https://apache-airflow.slack.com/archives/C099751BPHT)
 

--- a/docs/configuration/custom_py_object.md
+++ b/docs/configuration/custom_py_object.md
@@ -38,14 +38,14 @@ The generalized object feature is **extremely flexible**—it supports Python ty
 !!! note
     If you use a custom or third-party class, make sure it is installed and importable in your Airflow environment.
 
-| Python Object/Class                        | YAML `__type__` Value                        | Example Use Case                |
-|--------------------------------------------|----------------------------------------------|---------------------------------|
-| `datetime.datetime`                        | `datetime.datetime`                          | DAG start date                  |
-| `datetime.timedelta`                       | `datetime.timedelta`                         | Task timeout                    |
-| `airflow.timetables.trigger.CronTriggerTimetable` | `airflow.timetables.trigger.CronTriggerTimetable` | Custom scheduling               |
-| `airflow.sdk.Asset`                        | `airflow.sdk.Asset`                          | Asset definition                |
-| `airflow.io.path.ObjectStoragePath`        | `airflow.io.path.ObjectStoragePath`           | Object storage path             |
-| `kubernetes.client.models.V1Pod`           | `kubernetes.client.models.V1Pod`              | Kubernetes pod override         |
+| Python Object/Class                               | YAML `__type__` Value                             | Example Use Case        |
+| ------------------------------------------------- | ------------------------------------------------- | ----------------------- |
+| `datetime.datetime`                               | `datetime.datetime`                               | DAG start date          |
+| `datetime.timedelta`                              | `datetime.timedelta`                              | Task timeout            |
+| `airflow.timetables.trigger.CronTriggerTimetable` | `airflow.timetables.trigger.CronTriggerTimetable` | Custom scheduling       |
+| `airflow.sdk.Asset`                               | `airflow.sdk.Asset`                               | Asset definition        |
+| `airflow.io.path.ObjectStoragePath`               | `airflow.io.path.ObjectStoragePath`               | Object storage path     |
+| `kubernetes.client.models.V1Pod`                  | `kubernetes.client.models.V1Pod`                  | Kubernetes pod override |
 
 ---
 

--- a/docs/configuration/environment_variables.md
+++ b/docs/configuration/environment_variables.md
@@ -23,8 +23,8 @@ By default DAG Factory logs the error and skips DAGs that fail to build so other
 or folder can still be loaded. Setting strict mode raises an exception for every problematic DAG while still
 registering all DAGs that built successfully.
 
-| Variable | Section | Key | Default |
-|---|---|---|---|
+| Variable                            | Section       | Key           | Default |
+| ----------------------------------- | ------------- | ------------- | ------- |
 | `AIRFLOW__DAG_FACTORY__STRICT_MODE` | `dag_factory` | `strict_mode` | `False` |
 
 ```bash

--- a/docs/features/taskflow_pipeline.md
+++ b/docs/features/taskflow_pipeline.md
@@ -23,7 +23,7 @@ def collect(**context):
     return {"key1": "value1", "key2": "value2"}
 ```
 
-It's representation in dag_factory yaml is like
+Its representation in dag_factory YAML looks like:
 
 ```yaml
 - task_id: collect

--- a/docs/features/taskflow_pipeline.md
+++ b/docs/features/taskflow_pipeline.md
@@ -18,7 +18,7 @@ enabling "getitem" shorthand for TaskFlow-style decorated tasks that return mapp
 Given a TaskFlow task `collect` that returns a multiple_outputs dict like:
 
 ```python
-@task(multiple_ouputs=True)
+@task(multiple_outputs=True)
 def collect(**context):
     return {"key1": "value1", "key2": "value2"}
 ```

--- a/docs/features/taskflow_pipeline.md
+++ b/docs/features/taskflow_pipeline.md
@@ -1,30 +1,31 @@
-## TaskFlow Pipeline with `multiple_outputs=True`
+# TaskFlow Pipeline with `multiple_outputs=True`
 
 DAG Factory supports Airflow’s
 [Pythonic Dags with the TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html),
 enabling "getitem" shorthand for TaskFlow-style decorated tasks that return mappings (multiple_outputs=True).
 
-### What it enables
+## What it enables
 
 - When a TaskFlow-decorated task returns a dict (for example, using `multiple_outputs=True`), downstream task arguments can reference either the whole returned mapping or a single key from it using a concise syntax.
 
-### Syntax
+## Syntax
 
 - `+task_id` (with default `multiple_outputs=False`) — reference the entire Python function return value (the pushed value from the task). This is useful when the upstream task returns a mapping and the downstream callable expects the return_value.
 - `+task_id['key']` or `+task_id["key"]` — reference a single value from the mapping returned by the upstream TaskFlow task.
 
-### Examples
+## Examples
 
 Given a TaskFlow task `collect` that returns a multiple_outputs dict like:
 
-```
+```python
 @task(multiple_ouputs=True)
 def collect(**context):
     return {"key1": "value1", "key2": "value2"}
 ```
 
 It's representation in dag_factory yaml is like
-```
+
+```yaml
 - task_id: collect
   multiple_outputs: true
   decorator: airflow.decorators.task
@@ -33,6 +34,6 @@ It's representation in dag_factory yaml is like
 
 Then you can use a single value from the mapping with:
 
-```
+```yaml
 value: "+collect['key1']"
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Version **1.0** introduces important improvements and breaking changes to suppor
 
 DAG-Factory is compatible with **Apache Airflow 3** and supports modern scheduling, and updated import paths.
 
-##  Community
+## Community
 
 Join us on the Apache Airflow Slack Workspace at [#yaml-dags](https://apache-airflow.slack.com/archives/C099751BPHT)
 


### PR DESCRIPTION
## Summary

Companion to #763 (which bumps the `markdownlint` pre-commit hook to v0.48.0). Running markdownlint **0.48.0** over the repo surfaces **34 pre-existing violations across 7 docs files** — mostly the new **MD060** (table alignment) and **MD050** (strong-style) rules, plus MD040/MD041/MD019/MD031/MD047/MD007. They don't block CI today (Static-Check only feeds `dagfactory/* uv.lock` to pre-commit, so the `*.md` hooks aren't exercised), but they would block the next edit to any affected doc once #763 lands.

This clears them so the docs lint clean under 0.48.0:

- **MD019 / MD050 / MD007 / MD031 / MD047** — auto-fixed via `markdownlint --fix`.
- **MD040** — added languages to fenced code blocks (`text` in AGENTS.md; `python` / `yaml` in taskflow_pipeline.md).
- **MD041 / MD001** — promoted `docs/features/taskflow_pipeline.md`'s title to H1 and shifted its subsections to H2.
- **MD060** — aligned the tables in `custom_py_object.md` and `environment_variables.md`.

## Verification

`pre-commit run markdownlint --all-files` with markdownlint-cli 0.48.0 passes clean. CI itself does not run markdownlint, so this was verified locally.

Pairs with #763 — merge in either order; together they make the docs clean under the new linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
