### PR TITLE
Bump codecov/codecov-action to v6.0.2 to fix coverage upload failure

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -277,7 +277,7 @@ jobs:
           coverage report
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           # Only fail CI if error when token is available (internal PRs and pushes)
           # External PRs from forks don't have access to secrets


### PR DESCRIPTION
## What

Bumps `codecov/codecov-action` from `v6.0.1` (`e79a696`) to `v6.0.2` (`fb8b358`) in `.github/workflows/cicd.yaml`.

## Why

The Codecov upload step is failing CI on every run, e.g. [this failed run](https://github.com/astronomer/dag-factory/actions/runs/27205044280/job/80319862606) where the "Upload coverage to Codecov" step exits with code 1.

`v6.0.1` and earlier are broken by Codecov's Keybase/GPG account migration, which fails the GPG verification step and causes the coverage upload to fail. `v6.0.2` (released 2026-06-07) contains the fix for this verification failure.

This mirrors the same fix applied in astronomer-cosmos: astronomer/astronomer-cosmos#2786.

## Note

This intentionally bypasses the usual 7-day cooldown for GitHub Actions updates, since `v6.0.2` was only released on 2026-06-07 and waiting for the automatic Dependabot bump would leave CI broken for several more days. Coverage reporting is critical for the project, and the security risk of this patch-level update is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)