### PR TITLE
Exclude integration tests from unit test runs

### DIFF
--- a/scripts/test/unit-cov.sh
+++ b/scripts/test/unit-cov.sh
@@ -6,4 +6,5 @@ env -u AIRFLOW_HOME pytest \
     --cov=dagfactory \
     --cov-report=term-missing \
     --cov-report=xml \
+    -m "not integration" \
     --ignore=tests/test_example_dags.py

--- a/scripts/test/unit.sh
+++ b/scripts/test/unit.sh
@@ -1,3 +1,4 @@
 pytest \
     -vv \
+    -m "not integration" \
     --ignore=tests/test_example_dags.py


### PR DESCRIPTION
## What

Adds `-m "not integration"` to the unit-test pytest invocations in `scripts/test/unit.sh` and `scripts/test/unit-cov.sh`, so the unit-test CI job no longer collects and runs integration-marked tests.

## Why

The unit-test job (`hatch run …:test-cov` → `scripts/test/unit-cov.sh`) only excluded `tests/test_example_dags.py` and had no marker filter, so `@pytest.mark.integration` tests were silently being run in the unit job as well as the dedicated integration job.

This surfaced as a flaky failure in [this run](https://github.com/astronomer/dag-factory/actions/runs/27205892997/job/80321504057), where `tests/test_telemetry.py::test_emit_usage_metrics_succeeds` (marked `@pytest.mark.integration`) failed because it makes a real network call to `astronomer.gateway.scarf.sh`, which timed out on the runner:

```
WARNING root:telemetry.py:53 Unable to emit usage metrics ... An error occurred: timed out.
>       assert is_success
E       assert False
FAILED tests/test_telemetry.py::test_emit_usage_metrics_succeeds - assert False
```

Integration tests rely on external resources/network and belong only in the dedicated integration job (`scripts/test/integration.sh`, which correctly runs `-m integration`). Excluding them from the unit run makes the unit job hermetic and removes this class of network-induced flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)