### PR TITLE
ci: selectively ignore zizmor cache-poisoning inline (keep caching)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -288,6 +288,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          version: "0.7.12"
           enable-cache: false  # no cache (zizmor cache-poisoning)
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -41,10 +41,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -126,11 +125,18 @@ jobs:
           echo "name=tests.py${PY_VERSION}-${AF_VERSION}${suffix}" >> "$GITHUB_OUTPUT"
           echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5  # zizmor: ignore[cache-poisoning]
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.cache/pip
+            .local/share/hatch/
+          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}${{ steps.hatch-env.outputs.suffix }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
+
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -192,11 +198,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5  # zizmor: ignore[cache-poisoning]
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.cache/pip
+            .local/share/hatch/
+          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
+
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -242,10 +255,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -286,10 +298,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: true
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -313,10 +322,9 @@ jobs:
           persist-credentials: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -362,10 +370,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
         with:
           version: "0.7.12"
-          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -125,18 +126,11 @@ jobs:
           echo "name=tests.py${PY_VERSION}-${AF_VERSION}${suffix}" >> "$GITHUB_OUTPUT"
           echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.cache/pip
-            .local/share/hatch/
-          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}${{ steps.hatch-env.outputs.suffix }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
-
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -198,18 +192,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.cache/pip
-            .local/share/hatch/
-          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
-
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -258,6 +245,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -299,6 +287,8 @@ jobs:
           persist-credentials: true
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false  # no cache (zizmor cache-poisoning)
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -325,6 +315,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -373,6 +364,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -298,7 +298,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: true
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false  # no cache on docs/publish job (zizmor cache-poisoning)
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -322,9 +324,10 @@ jobs:
           persist-credentials: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache on docs/publish job (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -370,9 +373,10 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.12"
+          enable-cache: false  # no cache on docs/publish job (zizmor cache-poisoning)
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
## Summary

The `zizmor` code-scanning check flags **`cache-poisoning`** on every cache step in `cicd.yaml` (7 `astral-sh/setup-uv` steps + 2 `actions/cache` steps), turning the check **red on routine PRs** (e.g. GitHub Actions version bumps).

`cicd.yaml` has a `release` trigger, so zizmor (correctly) treats every cache-enabled step as in scope. In practice the cache key is content-addressed (`hashFiles('pyproject.toml')`, `hashFiles('dagfactory/__init__.py')`) and the publish/deploy jobs don't restore these caches to build the released artifact, so the practical poisoning risk is low — but the rule still fires on every step.

This keeps caching (and its CI speedups) and suppresses the rule **selectively, per step**, with inline `# zizmor: ignore[cache-poisoning]` comments — rather than disabling caching workflow-wide.

## Changes

- Restore the `actions/cache` steps and default `setup-uv` caching that an earlier revision had removed.
- Add `# zizmor: ignore[cache-poisoning]` inline on each of the 9 flagged steps.

The directive is appended to the existing pinned-SHA comment on each `uses:` line (YAML treats it as a single comment; zizmor scans the comment text for the directive), so it travels with the step — no separate config file to maintain.

## Why inline ignore (not a config file)?

- **Per-step, co-located:** the suppression lives on the exact step it applies to, so it's visible in review and moves/deletes with the step. No `cicd.yaml:<line>` entries in a separate file that drift when the file is edited.
- **No fail-open whole-file ignore:** a brand-new cache step added later is **not** silently suppressed — it will be flagged until someone consciously adds the inline directive.
- **Keeps caching:** wheel/venv caches stay warm across runs.

## Verification

- Ran `zizmor 1.25.2` locally on the updated workflow: **`No findings to report. Good job! (9 ignored, ...)`** (exit 0), no config needed.
- `cicd.yaml` validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
