### PR TITLE
Promote @gyli to committer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astronomer/oss-integrations
+* @astronomer/oss-integrations @gyli

--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -7,6 +7,7 @@ Learn more about the project [contributors roles](roles.md).
 
 * Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti))
 * Pankaj Singh ([@pankajastro](https://github.com/pankajastro))
+* Guangyang Li ([@gyli](https://github.com/gyli))
 * Tatiana Al-Chueyr ([@tatiana](https://github.com/tatiana))
 
 ## Emeritus Committers


### PR DESCRIPTION
[Guangyang Li](https://github.com/gyli) (@gyli) is a software engineer at Uber. He has been contributing to DAG Factory consistently since June 2025 — 14 merged PRs spanning new features, Airflow 3 support, refactors, and docs. A few highlights:

- Features: `user_defined_macros` support (#693), DAG-level args in global defaults (#480), env vars in defaults (#452)
- Airflow 3 compatibility: TaskGroup import handling (#706)
- Code quality: unifying `import_from_string` (#694), finishing the `defaults_config_path` rename (#725)
- Docs & DX: `CONFIG_ROOT_DIR` contribution docs (#432), `AGENTS.md` for AI agents (#717)


Beyond the numbers, he consistently proposes thoughtful, long-term solutions and is a pleasure to collaborate with in review. We'd love to recognise his work by welcoming him as a DAG Factory committer — our first from outside Astronomer. 

Thank you, @gyli! 🎉 