### PR TITLE
chore(dependabot): widen gh-aw-actions ignore to cover sub-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
     default-days: 7
   directory: /
   ignore:
-  - dependency-name: "github/gh-aw-actions" # gh-aw compiler-managed action pin; keep ignored and refresh via gh aw compile.
+  - dependency-name: "github/gh-aw-actions*" # gh-aw compiler-managed action pin (incl. sub-actions like /setup); keep ignored and refresh via gh aw compile.
   labels:
   - dependencies
   package-ecosystem: github-actions


### PR DESCRIPTION
## What

Change the `github-actions` Dependabot ignore rule from:

```yaml
- dependency-name: "github/gh-aw-actions"
```

to:

```yaml
- dependency-name: "github/gh-aw-actions*"
```

## Why

The pattern lacked a trailing wildcard, so it only matched the bare `github/gh-aw-actions` and **missed sub-action paths** like `github/gh-aw-actions/setup`. As a result Dependabot opened #810 (`github/gh-aw-actions/setup` 0.79.6 → 0.80.9) even though these pins are **gh-aw compiler-managed** and are meant to be refreshed via `gh aw compile`, not merged from a Dependabot PR.

The `*` wildcard makes the ignore cover the action and all its sub-actions, so the compiler-managed pin won't be reopened by Dependabot again.

## Note

#810 was already merged, so the current pin may now be out of sync with `gh aw compile` — worth a `gh aw compile` refresh to reconcile (out of scope for this PR, which only stops the recurrence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)