### PR TITLE
ci: replace zizmor cache-poisoning ignores with disabled caching

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -41,9 +41,10 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.7.12"
+          enable-cache: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -125,18 +126,11 @@ jobs:
           echo "name=tests.py${PY_VERSION}-${AF_VERSION}${suffix}" >> "$GITHUB_OUTPUT"
           echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5.0.5  # zizmor: ignore[cache-poisoning]
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.cache/pip
-            .local/share/hatch/
-          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}${{ steps.hatch-env.outputs.suffix }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
-
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.7.12"
+          enable-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -198,18 +192,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5.0.5  # zizmor: ignore[cache-poisoning]
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.cache/pip
-            .local/share/hatch/
-          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('dagfactory/__init__.py') }}
-
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.7.12"
+          enable-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -255,9 +242,10 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0  # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.7.12"
+          enable-cache: false
 
       - name: Set up Python 3.11
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
## Summary

- Removes the 6 scattered inline `# zizmor: ignore[cache-poisoning]` comments in `cicd.yaml`, added in #791 as a stopgap.
- Removes the two `actions/cache` steps (`Run-Unit-Tests`, `Run-Integration-Tests`) and sets `enable-cache: false` on every remaining `astral-sh/setup-uv` step (`Static-Check`, `Run-Unit-Tests`, `Run-Integration-Tests`, `Code-Coverage`) — matching the pattern already used in `Build-Mkdocs`/`Deploy-Pages`/`Publish-Package`.

## Why disable caching instead of splitting the workflow

Investigated zizmor's `cache-poisoning` audit directly (ran it locally against several variants of `cicd.yaml`):

- It fires purely because the **workflow file** declares a `release:` trigger anywhere in `on:`, combined with any cache-enabling step anywhere in that file. Job-level `if:` conditions and conditional cache-disabling expressions don't suppress it — zizmor does file-level trigger analysis, not per-job reachability analysis (verified: adding `if: github.event_name != 'release'` to the test jobs did not clear the findings).
- The only way to keep caching *and* clear the findings would be to split every `release`-triggered job (`Publish-Package` and the release-docs path of `Deploy-Pages`) into a separate workflow. That's the Cosmos `deploy.yml` pattern referenced in the issue, but it would drop the in-workflow `needs:` gate that makes `Publish-Package` wait for the full test suite (`Static-Check`, `Run-Unit-Tests`, `Run-Integration-Tests`, `Code-Coverage`) to pass before publishing to PyPI — GitHub Actions has no cross-workflow `needs:`. We don't want to lose that pre-publish test gate.

Given that, disabling caching outright is the simplest fix that keeps the single workflow and the full pre-publish gate intact. It's also close to free: comparing a real cache-hit run against a genuine cache-miss run (the 1.1.0 release commit, which bumped the cache key via `dagfactory/__init__.py`) shows the `actions/cache` step was only saving ~3-7 seconds per job on `Install packages and dependencies`. Since matrix jobs run in parallel, this has no meaningful wall-clock impact on PRs — it costs a few extra minutes of aggregate Actions runtime per full CI run, nothing more.

## Verification

- `zizmor --no-online-audits .github/workflows/cicd.yaml` → `No findings to report.` (exit 0), no ignores, no config needed.

Closes: BOSS-528

🤖 Generated with [Claude Code](https://claude.com/claude-code)