### PR TITLE
Add list for callback fields

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1207,14 +1207,14 @@ class DagBuilder:
     @staticmethod
     def set_callback(
         parameters: dict, callback_type: str, has_name_and_file=False
-    ) -> Union[Callable, List[Callable]]:
+    ) -> Any:
         """
         Update the passed-in config with the callback.
 
         :param parameters:
         :param callback_type:
         :param has_name_and_file:
-        :returns: Callable or list of Callables
+        :returns: a callable, an Airflow BaseNotifier instance, or a list thereof
         """
 
         # There is scenario where a callback is passed in via a file and a name. For the most part, this will be a
@@ -1259,7 +1259,9 @@ class DagBuilder:
 
                     return partial(on_state_callback_callable, **on_state_callback_params)
 
-        # A list of callbacks — each entry resolved using the same string/dict rules as above.
+        # A list of callbacks — each string entry is imported as-is; each dict entry follows the
+        # same callback/kwargs resolution as the single-dict branch, except a dict with no extra
+        # kwargs returns the plain callable directly instead of wrapping in an empty partial.
         elif isinstance(parameters[callback_type], list):
             resolved: List[Callable] = []
             for item in parameters[callback_type]:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1209,26 +1209,26 @@ class DagBuilder:
         """Resolve a single str-or-dict callback entry to a callable or notifier."""
         if isinstance(entry, str):
             return import_string(entry)
-        if isinstance(entry, dict):
-            if not utils.check_dict_key(entry, "callback"):
-                raise DagFactoryConfigException(
-                    f"'{callback_type}' dict entry is missing a required 'callback' key "
-                    f"(expected a string import path, e.g. 'my.module.my_callback')"
-                )
-            if not isinstance(entry["callback"], str):
-                raise DagFactoryConfigException(
-                    f"'{callback_type}' dict entry 'callback' value must be a string import path, "
-                    f"got {type(entry['callback']).__name__}"
-                )
-            callback_callable = import_string(entry["callback"])
-            params = {k: v for k, v in entry.items() if k != "callback"}
-            if hasattr(callback_callable, "notify"):
-                return callback_callable(**params)
-            return partial(callback_callable, **params) if params else callback_callable
-        raise DagFactoryConfigException(
-            f"Invalid type passed to {callback_type}: expected a string import path or a dict "
-            f"with a 'callback' key, got {type(entry).__name__}"
-        )
+        if not isinstance(entry, dict):
+            raise DagFactoryConfigException(
+                f"Invalid type passed to {callback_type}: expected a string import path or a dict "
+                f"with a 'callback' key, got {type(entry).__name__}"
+            )
+        if not utils.check_dict_key(entry, "callback"):
+            raise DagFactoryConfigException(
+                f"'{callback_type}' dict entry is missing a required 'callback' key "
+                f"(expected a string import path, e.g. 'my.module.my_callback')"
+            )
+        if not isinstance(entry["callback"], str):
+            raise DagFactoryConfigException(
+                f"'{callback_type}' dict entry 'callback' value must be a string import path, "
+                f"got {type(entry['callback']).__name__}"
+            )
+        callback_callable = import_string(entry["callback"])
+        params = {k: v for k, v in entry.items() if k != "callback"}
+        if hasattr(callback_callable, "notify"):
+            return callback_callable(**params)
+        return partial(callback_callable, **params) if params else callback_callable
 
     @staticmethod
     def set_callback(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1259,10 +1259,7 @@ class DagBuilder:
 
                     return partial(on_state_callback_callable, **on_state_callback_params)
 
-        # A list of callbacks — each entry is either a plain import string or a dict with a
-        # "callback" key plus optional kwargs. Resolution per entry mirrors the string/dict branches
-        # above, with one difference: a dict entry with no extra kwargs returns the plain callable
-        # directly (no empty partial), since there is nothing to bind.
+        # A list of callbacks — each entry resolved using the same string/dict rules as above.
         elif isinstance(parameters[callback_type], list):
             resolved: List[Callable] = []
             for item in parameters[callback_type]:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1259,9 +1259,8 @@ class DagBuilder:
 
                     return partial(on_state_callback_callable, **on_state_callback_params)
 
-        # A list of callbacks — each string entry is imported as-is; each dict entry follows the
-        # same callback/kwargs resolution as the single-dict branch, except a dict with no extra
-        # kwargs returns the plain callable directly instead of wrapping in an empty partial.
+        # A list of callbacks — same string/dict resolution as above; dict with no kwargs returns
+        # the callable directly rather than wrapping in an empty partial.
         elif isinstance(parameters[callback_type], list):
             resolved: List[Callable] = []
             for item in parameters[callback_type]:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1210,14 +1210,25 @@ class DagBuilder:
         if isinstance(entry, str):
             return import_string(entry)
         if isinstance(entry, dict):
-            if not utils.check_dict_key(entry, "callback") or not isinstance(entry["callback"], str):
-                raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")
-            cb = import_string(entry["callback"])
+            if not utils.check_dict_key(entry, "callback"):
+                raise DagFactoryConfigException(
+                    f"'{callback_type}' dict entry is missing a required 'callback' key "
+                    f"(expected a string import path, e.g. 'my.module.my_callback')"
+                )
+            if not isinstance(entry["callback"], str):
+                raise DagFactoryConfigException(
+                    f"'{callback_type}' dict entry 'callback' value must be a string import path, "
+                    f"got {type(entry['callback']).__name__}"
+                )
+            callback_callable = import_string(entry["callback"])
             params = {k: v for k, v in entry.items() if k != "callback"}
-            if hasattr(cb, "notify"):
-                return cb(**params)
-            return partial(cb, **params) if params else cb
-        raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")
+            if hasattr(callback_callable, "notify"):
+                return callback_callable(**params)
+            return partial(callback_callable, **params) if params else callback_callable
+        raise DagFactoryConfigException(
+            f"Invalid type passed to {callback_type}: expected a string import path or a dict "
+            f"with a 'callback' key, got {type(entry).__name__}"
+        )
 
     @staticmethod
     def set_callback(
@@ -1232,13 +1243,13 @@ class DagBuilder:
         :returns: a callable, an Airflow BaseNotifier instance, or a list thereof
         """
         if has_name_and_file:
-            cb = utils.get_python_callable(
+            callback_callable = utils.get_python_callable(
                 python_callable_name=parameters[f"{callback_type}_name"],
                 python_callable_file=parameters[f"{callback_type}_file"],
             )
             del parameters[f"{callback_type}_name"]
             del parameters[f"{callback_type}_file"]
-            return cb
+            return callback_callable
 
         value = parameters[callback_type]
         if isinstance(value, list):

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1228,7 +1228,7 @@ class DagBuilder:
         params = {k: v for k, v in entry.items() if k != "callback"}
         if hasattr(callback_callable, "notify"):
             return callback_callable(**params)
-        return partial(callback_callable, **params) if params else callback_callable
+        return partial(callback_callable, **params)
 
     @staticmethod
     def set_callback(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1231,9 +1231,7 @@ class DagBuilder:
         return partial(callback_callable, **params)
 
     @staticmethod
-    def set_callback(
-        parameters: dict, callback_type: str, has_name_and_file=False
-    ) -> Any:
+    def set_callback(parameters: dict, callback_type: str, has_name_and_file=False) -> Any:
         """
         Update the passed-in config with the callback.
 
@@ -1258,8 +1256,6 @@ class DagBuilder:
                 try:
                     resolved.append(DagBuilder._resolve_callback_entry(item, callback_type))
                 except DagFactoryConfigException as exc:
-                    raise DagFactoryConfigException(
-                        f"{callback_type}[{i}]: {exc}"
-                    ) from exc
+                    raise DagFactoryConfigException(f"{callback_type}[{i}]: {exc}") from exc
             return resolved
         return DagBuilder._resolve_callback_entry(value, callback_type)

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1253,5 +1253,13 @@ class DagBuilder:
 
         value = parameters[callback_type]
         if isinstance(value, list):
-            return [DagBuilder._resolve_callback_entry(item, callback_type) for item in value]
+            resolved = []
+            for i, item in enumerate(value):
+                try:
+                    resolved.append(DagBuilder._resolve_callback_entry(item, callback_type))
+                except DagFactoryConfigException as exc:
+                    raise DagFactoryConfigException(
+                        f"{callback_type}[{i}]: {exc}"
+                    ) from exc
+            return resolved
         return DagBuilder._resolve_callback_entry(value, callback_type)

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1205,6 +1205,21 @@ class DagBuilder:
             DagBuilder._replace_kwargs_values_as_xcom(kwargs, key, value, tasks_dict)
 
     @staticmethod
+    def _resolve_callback_entry(entry: Any, callback_type: str) -> Any:
+        """Resolve a single str-or-dict callback entry to a callable or notifier."""
+        if isinstance(entry, str):
+            return import_string(entry)
+        if isinstance(entry, dict):
+            if not utils.check_dict_key(entry, "callback") or not isinstance(entry["callback"], str):
+                raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")
+            cb = import_string(entry["callback"])
+            params = {k: v for k, v in entry.items() if k != "callback"}
+            if hasattr(cb, "notify"):
+                return cb(**params)
+            return partial(cb, **params) if params else cb
+        raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")
+
+    @staticmethod
     def set_callback(
         parameters: dict, callback_type: str, has_name_and_file=False
     ) -> Any:
@@ -1216,78 +1231,16 @@ class DagBuilder:
         :param has_name_and_file:
         :returns: a callable, an Airflow BaseNotifier instance, or a list thereof
         """
-
-        # There is scenario where a callback is passed in via a file and a name. For the most part, this will be a
-        # Python callable that is treated similarly to a Python callable that the PythonOperator may leverage. That
-        # being said, what if this is not a Python callable? What if this is another type?
         if has_name_and_file:
-            on_state_callback_callable: Callable = utils.get_python_callable(
+            cb = utils.get_python_callable(
                 python_callable_name=parameters[f"{callback_type}_name"],
                 python_callable_file=parameters[f"{callback_type}_file"],
             )
-
-            # Delete the callback_type name and file
             del parameters[f"{callback_type}_name"]
             del parameters[f"{callback_type}_file"]
+            return cb
 
-            return on_state_callback_callable
-
-        # If the value stored at parameters[callback_type] is a string, it should be imported under the assumption that
-        # it is a function that is "ready to be called". If not returning the function, something like this could be
-        # used to update the config parameters[callback_type] = import_string(parameters[callback_type])
-        if isinstance(parameters[callback_type], str):
-            return import_string(parameters[callback_type])
-
-        # Otherwise, if the parameter[callback_type] is a dictionary, it should be treated similar to the Python
-        # callable
-        elif isinstance(parameters[callback_type], dict):
-            # Pull the on_failure_callback dictionary from dag_params
-            on_state_callback_params: dict = parameters[callback_type]
-
-            # Check to see if there is a "callback" key in the on_failure_callback dictionary. If there is, parse
-            # out that callable, and add the parameters
-            if utils.check_dict_key(on_state_callback_params, "callback"):
-                if isinstance(on_state_callback_params["callback"], str):
-                    on_state_callback_callable: Callable = import_string(on_state_callback_params["callback"])
-                    del on_state_callback_params["callback"]
-
-                    # Return the callable, this time, using the params provided in the YAML file, rather than a .py
-                    # file with a callable configured. If not returning the partial, something like this could be used
-                    # to update the config ... parameters[callback_type]: Callable = partial(...)
-                    if hasattr(on_state_callback_callable, "notify"):
-                        return on_state_callback_callable(**on_state_callback_params)
-
-                    return partial(on_state_callback_callable, **on_state_callback_params)
-
-        # A list of callbacks — same string/dict resolution as above; dict with no kwargs returns
-        # the callable directly rather than wrapping in an empty partial.
-        elif isinstance(parameters[callback_type], list):
-            resolved: List[Callable] = []
-            for item in parameters[callback_type]:
-                if isinstance(item, str):
-                    resolved.append(import_string(item))
-                elif isinstance(item, dict):
-                    if not utils.check_dict_key(item, "callback"):
-                        raise DagFactoryConfigException(
-                            f"Each list entry for '{callback_type}' must contain a 'callback' key"
-                        )
-                    if not isinstance(item["callback"], str):
-                        raise DagFactoryConfigException(
-                            f"The 'callback' value in a '{callback_type}' list entry must be a string import path, "
-                            f"got {type(item['callback']).__name__}"
-                        )
-                    item_callable: Callable = import_string(item["callback"])
-                    item_params = {k: v for k, v in item.items() if k != "callback"}
-                    if hasattr(item_callable, "notify"):
-                        resolved.append(item_callable(**item_params))
-                    elif item_params:
-                        resolved.append(partial(item_callable, **item_params))
-                    else:
-                        resolved.append(item_callable)
-                else:
-                    raise DagFactoryConfigException(
-                        f"Invalid type in '{callback_type}' list: expected str or dict, got {type(item).__name__}"
-                    )
-            return resolved
-
-        raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")
+        value = parameters[callback_type]
+        if isinstance(value, list):
+            return [DagBuilder._resolve_callback_entry(item, callback_type) for item in value]
+        return DagBuilder._resolve_callback_entry(value, callback_type)

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1205,7 +1205,9 @@ class DagBuilder:
             DagBuilder._replace_kwargs_values_as_xcom(kwargs, key, value, tasks_dict)
 
     @staticmethod
-    def set_callback(parameters: Union[dict, str], callback_type: str, has_name_and_file=False) -> Callable:
+    def set_callback(
+        parameters: Union[dict, str], callback_type: str, has_name_and_file=False
+    ) -> Union[Callable, List[Callable]]:
         """
         Update the passed-in config with the callback.
 
@@ -1256,5 +1258,32 @@ class DagBuilder:
                         return on_state_callback_callable(**on_state_callback_params)
 
                     return partial(on_state_callback_callable, **on_state_callback_params)
+
+        # A list of callbacks — each entry is either a plain import string or a dict with a
+        # "callback" key plus optional kwargs (same resolution rules as the single-entry branches
+        # above). This mirrors how Airflow itself accepts on_*_callback as a list.
+        elif isinstance(parameters[callback_type], list):
+            resolved: List[Callable] = []
+            for item in parameters[callback_type]:
+                if isinstance(item, str):
+                    resolved.append(import_string(item))
+                elif isinstance(item, dict):
+                    if not utils.check_dict_key(item, "callback"):
+                        raise DagFactoryConfigException(
+                            f"Each list entry for '{callback_type}' must contain a 'callback' key"
+                        )
+                    item_callable: Callable = import_string(item["callback"])
+                    item_params = {k: v for k, v in item.items() if k != "callback"}
+                    if hasattr(item_callable, "notify"):
+                        resolved.append(item_callable(**item_params))
+                    elif item_params:
+                        resolved.append(partial(item_callable, **item_params))
+                    else:
+                        resolved.append(item_callable)
+                else:
+                    raise DagFactoryConfigException(
+                        f"Invalid type in '{callback_type}' list: expected str or dict, got {type(item).__name__}"
+                    )
+            return resolved
 
         raise DagFactoryConfigException(f"Invalid type passed to {callback_type}")

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -1206,7 +1206,7 @@ class DagBuilder:
 
     @staticmethod
     def set_callback(
-        parameters: Union[dict, str], callback_type: str, has_name_and_file=False
+        parameters: dict, callback_type: str, has_name_and_file=False
     ) -> Union[Callable, List[Callable]]:
         """
         Update the passed-in config with the callback.
@@ -1214,7 +1214,7 @@ class DagBuilder:
         :param parameters:
         :param callback_type:
         :param has_name_and_file:
-        :returns: Callable
+        :returns: Callable or list of Callables
         """
 
         # There is scenario where a callback is passed in via a file and a name. For the most part, this will be a
@@ -1260,8 +1260,9 @@ class DagBuilder:
                     return partial(on_state_callback_callable, **on_state_callback_params)
 
         # A list of callbacks — each entry is either a plain import string or a dict with a
-        # "callback" key plus optional kwargs (same resolution rules as the single-entry branches
-        # above). This mirrors how Airflow itself accepts on_*_callback as a list.
+        # "callback" key plus optional kwargs. Resolution per entry mirrors the string/dict branches
+        # above, with one difference: a dict entry with no extra kwargs returns the plain callable
+        # directly (no empty partial), since there is nothing to bind.
         elif isinstance(parameters[callback_type], list):
             resolved: List[Callable] = []
             for item in parameters[callback_type]:
@@ -1271,6 +1272,11 @@ class DagBuilder:
                     if not utils.check_dict_key(item, "callback"):
                         raise DagFactoryConfigException(
                             f"Each list entry for '{callback_type}' must contain a 'callback' key"
+                        )
+                    if not isinstance(item["callback"], str):
+                        raise DagFactoryConfigException(
+                            f"The 'callback' value in a '{callback_type}' list entry must be a string import path, "
+                            f"got {type(item['callback']).__name__}"
                         )
                     item_callable: Callable = import_string(item["callback"])
                     item_params = {k: v for k, v in item.items() if k != "callback"}

--- a/docs/features/callbacks.md
+++ b/docs/features/callbacks.md
@@ -4,7 +4,7 @@ DAG Factory supports the use of callbacks. These callbacks can be set at the DAG
 that callbacks that can be configured for DAGs, TaskGroups, and Tasks differ slightly, and details around this can be
 found in the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#).
 
-Within DAG Factory itself, there are three approaches to defining callbacks. The goal is to make this process
+Within DAG Factory itself, there are four approaches to defining callbacks. The goal is to make this process
 intuitive and provide parity with the traditional DAG authoring experience. These approaches to configure callbacks
 are outlined below, each with an example of implementation. While proceeding examples are all defined for individual
 Tasks, callbacks can also be defined using `default_args`, or at the DAG and TaskGroup level.

--- a/docs/features/callbacks.md
+++ b/docs/features/callbacks.md
@@ -11,6 +11,7 @@ Tasks, callbacks can also be defined using `default_args`, or at the DAG and Tas
 
 * [Passing a string that points to a callable](#passing-a-string-that-points-to-a-callable)
 * [Specifying a user-defined `.py` and the function within that file to be executed](#specifying-a-user-defined-py-file-and-function)
+* [Multiple callbacks](#multiple-callbacks)
 * [Configuring callbacks from providers](#provider-callbacks)
 
 ## Passing a string that points to a callable
@@ -69,6 +70,34 @@ specified for a DAG, TaskGroup, or Task. This provides a viable option for defin
 
 Note that this method for defining callbacks in DAG Factory does not allow for parameters to be passed to the callable
 within the YAML itself.
+
+## Multiple callbacks
+
+Airflow accepts a list for any `on_*_callback` field, allowing multiple independent callbacks to run sequentially on the same event. DAG Factory supports the same pattern — any callback field can be set to a YAML list where each entry follows the same string or dict format as the single-entry examples above.
+
+```yaml
+...
+  - task_id: task_3
+    operator: airflow.operators.bash_operator.BashOperator
+    bash_command: "echo task_3"
+    on_failure_callback:
+      - callback: include.custom_callbacks.send_alert_to_datadog
+      - callback: airflow.providers.smtp.notifications.smtp.SmtpNotifier
+        to:
+          - team@example.com
+...
+```
+
+This is also supported at the DAG level and in `default_args`:
+
+```yaml
+default_args:
+  on_failure_callback:
+    - include.custom_callbacks.send_alert_to_datadog
+    - callback: airflow.providers.smtp.notifications.smtp.SmtpNotifier
+      to:
+        - team@example.com
+```
 
 ## Provider callbacks
 

--- a/docs/features/callbacks.md
+++ b/docs/features/callbacks.md
@@ -78,7 +78,7 @@ Airflow accepts a list for any `on_*_callback` field, allowing multiple independ
 ```yaml
 ...
   - task_id: task_3
-    operator: airflow.operators.bash_operator.BashOperator
+    operator: airflow.operators.bash.BashOperator
     bash_command: "echo task_3"
     on_failure_callback:
       - callback: include.custom_callbacks.send_alert_to_datadog

--- a/docs/features/callbacks.md
+++ b/docs/features/callbacks.md
@@ -6,7 +6,7 @@ found in the [Apache Airflow documentation](https://airflow.apache.org/docs/apac
 
 Within DAG Factory itself, there are four approaches to defining callbacks. The goal is to make this process
 intuitive and provide parity with the traditional DAG authoring experience. These approaches to configure callbacks
-are outlined below, each with an example of implementation. While proceeding examples are all defined for individual
+are outlined below, each with an example of implementation. While preceding examples are all defined for individual
 Tasks, callbacks can also be defined using `default_args`, or at the DAG and TaskGroup level.
 
 * [Passing a string that points to a callable](#passing-a-string-that-points-to-a-callable)

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -844,6 +844,7 @@ def test_set_callback_with_list():
             {
                 "callback": f"{__name__}.empty_callback_with_params",
                 "param_1": "value_1",
+                "param_2": "value_2",
             }
         ]
     }
@@ -852,6 +853,7 @@ def test_set_callback_with_list():
     assert len(result) == 1
     assert isinstance(result[0], functools.partial)
     assert result[0].keywords["param_1"] == "value_1"
+    assert result[0].keywords["param_2"] == "value_2"
 
     # --- list with a dict entry that has no extra kwargs (plain callable) ---
     params = {
@@ -870,7 +872,8 @@ def test_set_callback_with_list():
             f"{__name__}.print_context_callback",
             {
                 "callback": f"{__name__}.empty_callback_with_params",
-                "param_1": "v",
+                "param_1": "v1",
+                "param_2": "v2",
             },
         ]
     }
@@ -879,6 +882,13 @@ def test_set_callback_with_list():
     assert callable(result[0])
     assert result[0].__name__ == "print_context_callback"
     assert isinstance(result[1], functools.partial)
+
+    # --- non-string 'callback' value in dict entry raises ---
+    with pytest.raises(DagFactoryConfigException, match="must be a string import path"):
+        DagBuilder.set_callback(
+            parameters={"on_failure_callback": [{"callback": 123}]},
+            callback_type="on_failure_callback",
+        )
 
 
 @pytest.mark.callbacks

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -802,14 +802,14 @@ def test_set_callback_exceptions():
         )
 
     # A list item that is neither str nor dict should raise
-    with pytest.raises(DagFactoryConfigException, match="Invalid type in 'on_failure_callback' list"):
+    with pytest.raises(DagFactoryConfigException, match="Invalid type passed to on_failure_callback"):
         DagBuilder.set_callback(
             parameters={"on_failure_callback": [42]},
             callback_type="on_failure_callback",
         )
 
     # A list item that is a dict but missing the 'callback' key should raise
-    with pytest.raises(DagFactoryConfigException, match="must contain a 'callback' key"):
+    with pytest.raises(DagFactoryConfigException, match="Invalid type passed to on_failure_callback"):
         DagBuilder.set_callback(
             parameters={"on_failure_callback": [{"not_callback": "foo"}]},
             callback_type="on_failure_callback",
@@ -884,7 +884,7 @@ def test_set_callback_with_list():
     assert isinstance(result[1], functools.partial)
 
     # --- non-string 'callback' value in dict entry raises ---
-    with pytest.raises(DagFactoryConfigException, match="must be a string import path"):
+    with pytest.raises(DagFactoryConfigException, match="Invalid type passed to on_failure_callback"):
         DagBuilder.set_callback(
             parameters={"on_failure_callback": [{"callback": 123}]},
             callback_type="on_failure_callback",

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -808,8 +808,8 @@ def test_set_callback_exceptions():
             callback_type="on_failure_callback",
         )
 
-    # A list item that is a dict but missing the 'callback' key should raise
-    with pytest.raises(DagFactoryConfigException, match="Invalid type passed to on_failure_callback"):
+    # A list item that is a dict but missing the 'callback' key should raise with a descriptive message
+    with pytest.raises(DagFactoryConfigException, match="missing a required 'callback' key"):
         DagBuilder.set_callback(
             parameters={"on_failure_callback": [{"not_callback": "foo"}]},
             callback_type="on_failure_callback",
@@ -883,32 +883,40 @@ def test_set_callback_with_list():
     assert result[0].__name__ == "print_context_callback"
     assert isinstance(result[1], functools.partial)
 
-    # --- non-string 'callback' value in dict entry raises ---
-    with pytest.raises(DagFactoryConfigException, match="Invalid type passed to on_failure_callback"):
+    # --- non-string 'callback' value in dict entry raises with a descriptive message ---
+    with pytest.raises(DagFactoryConfigException, match="'callback' value must be a string import path"):
         DagBuilder.set_callback(
             parameters={"on_failure_callback": [{"callback": 123}]},
             callback_type="on_failure_callback",
         )
 
     # --- list with a notifier-style entry (hasattr "notify") ---
-    # Uses the Slack notifier as a representative BaseNotifier, consistent with existing tests.
-    from airflow.providers.slack.notifications.slack import send_slack_notification
+    # Uses a local dummy notifier to avoid requiring optional provider packages in the test env.
+    class _DummyNotifier:
+        def __init__(self, channel):
+            self.channel = channel
 
-    params = {
-        "on_failure_callback": [
-            {
-                "callback": "airflow.providers.slack.notifications.slack.send_slack_notification",
-                "slack_conn_id": "slack_default",
-                "text": "DAG failed",
-                "channel": "#alerts",
-                "username": "airflow",
-            }
-        ]
-    }
-    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+        def notify(self, context):
+            pass
+
+    def dummy_notifier_factory(channel):
+        return _DummyNotifier(channel=channel)
+
+    dummy_notifier_factory.notify = True  # makes hasattr(callable_, "notify") truthy
+
+    import unittest.mock as mock
+
+    with mock.patch("dagfactory.dagbuilder.import_string", return_value=dummy_notifier_factory):
+        params = {
+            "on_failure_callback": [
+                {"callback": "my.dummy.notifier", "channel": "#alerts"}
+            ]
+        }
+        result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+
     assert isinstance(result, list)
     assert len(result) == 1
-    assert isinstance(result[0], send_slack_notification)
+    assert isinstance(result[0], _DummyNotifier)
     assert result[0].channel == "#alerts"
 
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -890,6 +890,27 @@ def test_set_callback_with_list():
             callback_type="on_failure_callback",
         )
 
+    # --- list with a notifier-style entry (hasattr "notify") ---
+    # Uses the Slack notifier as a representative BaseNotifier, consistent with existing tests.
+    from airflow.providers.slack.notifications.slack import send_slack_notification
+
+    params = {
+        "on_failure_callback": [
+            {
+                "callback": "airflow.providers.slack.notifications.slack.send_slack_notification",
+                "slack_conn_id": "slack_default",
+                "text": "DAG failed",
+                "channel": "#alerts",
+                "username": "airflow",
+            }
+        ]
+    }
+    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], send_slack_notification)
+    assert result[0].channel == "#alerts"
+
 
 @pytest.mark.callbacks
 def test_make_dag_with_callbacks():

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -791,16 +791,94 @@ def test_set_callback_exceptions():
     """
     test_set_callback_exceptions
 
-    Validate that exceptions are being throw for an incompatible version of Airflow, as well as for an invalid type
-    passed to the parameter config.
+    Validate that exceptions are being thrown for invalid types passed to the parameter config.
     """
-    # Test an exception parsing the parameters dictionary
+    # An int is still an invalid type
     invalid_type_passed_message = "Invalid type passed to on_execute_callback"
     with pytest.raises(DagFactoryConfigException, match=invalid_type_passed_message):
         DagBuilder.set_callback(
-            parameters={"on_execute_callback": ["callback_1", "callback_2", "callback_3"]},
+            parameters={"on_execute_callback": 42},
             callback_type="on_execute_callback",
         )
+
+    # A list item that is neither str nor dict should raise
+    with pytest.raises(DagFactoryConfigException, match="Invalid type in 'on_failure_callback' list"):
+        DagBuilder.set_callback(
+            parameters={"on_failure_callback": [42]},
+            callback_type="on_failure_callback",
+        )
+
+    # A list item that is a dict but missing the 'callback' key should raise
+    with pytest.raises(DagFactoryConfigException, match="must contain a 'callback' key"):
+        DagBuilder.set_callback(
+            parameters={"on_failure_callback": [{"not_callback": "foo"}]},
+            callback_type="on_failure_callback",
+        )
+
+
+@pytest.mark.callbacks
+def test_set_callback_with_list():
+    """
+    Validate that on_*_callback accepts a list of entries where each entry is either a
+    plain import string or a dict with a 'callback' key plus optional kwargs — mirroring
+    how Airflow itself accepts callbacks as a list.
+    """
+    import functools
+
+    # --- list of plain import strings ---
+    params = {
+        "on_failure_callback": [
+            f"{__name__}.print_context_callback",
+            f"{__name__}.print_context_callback",
+        ]
+    }
+    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(callable(cb) for cb in result)
+    assert all(cb.__name__ == "print_context_callback" for cb in result)
+
+    # --- list with a dict entry that has extra kwargs (becomes a partial) ---
+    params = {
+        "on_failure_callback": [
+            {
+                "callback": f"{__name__}.empty_callback_with_params",
+                "param_1": "value_1",
+            }
+        ]
+    }
+    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], functools.partial)
+    assert result[0].keywords["param_1"] == "value_1"
+
+    # --- list with a dict entry that has no extra kwargs (plain callable) ---
+    params = {
+        "on_failure_callback": [
+            {"callback": f"{__name__}.print_context_callback"}
+        ]
+    }
+    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+    assert isinstance(result, list)
+    assert callable(result[0])
+    assert result[0].__name__ == "print_context_callback"
+
+    # --- mixed: string + dict-with-kwargs ---
+    params = {
+        "on_failure_callback": [
+            f"{__name__}.print_context_callback",
+            {
+                "callback": f"{__name__}.empty_callback_with_params",
+                "param_1": "v",
+            },
+        ]
+    }
+    result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
+    assert len(result) == 2
+    assert callable(result[0])
+    assert result[0].__name__ == "print_context_callback"
+    assert isinstance(result[1], functools.partial)
 
 
 @pytest.mark.callbacks

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -855,7 +855,7 @@ def test_set_callback_with_list():
     assert result[0].keywords["param_1"] == "value_1"
     assert result[0].keywords["param_2"] == "value_2"
 
-    # --- list with a dict entry that has no extra kwargs (plain callable) ---
+    # --- list with a dict entry that has no extra kwargs (partial with no kwargs) ---
     params = {
         "on_failure_callback": [
             {"callback": f"{__name__}.print_context_callback"}
@@ -863,8 +863,9 @@ def test_set_callback_with_list():
     }
     result = DagBuilder.set_callback(parameters=params, callback_type="on_failure_callback")
     assert isinstance(result, list)
-    assert callable(result[0])
-    assert result[0].__name__ == "print_context_callback"
+    assert isinstance(result[0], functools.partial)
+    assert result[0].func.__name__ == "print_context_callback"
+    assert result[0].keywords == {}
 
     # --- mixed: string + dict-with-kwargs ---
     params = {

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -902,7 +902,7 @@ def test_set_callback_with_list():
     def dummy_notifier_factory(channel):
         return _DummyNotifier(channel=channel)
 
-    dummy_notifier_factory.notify = True  # makes hasattr(callable_, "notify") truthy
+    dummy_notifier_factory.notify = lambda context: None  # mirrors real notifier objects
 
     import unittest.mock as mock
 


### PR DESCRIPTION
## Summary

-Currently, Airflow natively accepts a list for callbacks (allowing multiple independent callbacks)
-dagfactory has no way of doing this in yaml
-The PR  adds a list to set_callback to remedy this

## Example YAML (new capability)

```yaml
default_args:
  on_failure_callback:
    - callback: my.project.callbacks.datadog_callback
    - callback: airflow.providers.smtp.notifications.smtp.SmtpNotifier
      to:
        - team@example.com
```

## Backward compatibility

Fully backward-compatible. Existing string and dict `on_*_callback` configs are unchanged. A list that contains invalid item types raises a descriptive `DagFactoryConfigException`.

## Test plan

- Tested locally by constructing a dag with one and two callbacks. The logs show that callbacks (both just one and two) are called correctly
- Updated `test_set_callback_exceptions` to use an `int` (still invalid) instead of a list (now valid)
- Added `test_set_callback_with_list` covering: list of strings, list with dict+kwargs (partial), list with dict without kwargs (plain callable), mixed list, invalid item type, missing `callback` key
