### PR TITLE
docs: Improve privacy policy

### DIFF
--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -10,7 +10,7 @@ Since May 2025, [Astro Runtime](https://www.astronomer.io/docs/runtime/runtime-r
 environment variable `SCARF_NO_ANALYTICS=True`, which disables DAG Factory telemetry by default:
 
 - Airflow 3-based images: Astro Runtime 3.0-2 and newer
-- Airflow 2-based images: Astro Runtime 11.18.0, 12.9.0, 13.0.0 and newer
+- Airflow 2-based images: Astro Runtime 11.18.0 and newer (11.x line), 12.9.0 and newer (12.x line), and all 13.x releases
 
 [Astro Private Cloud](https://www.astronomer.io/docs/astro-private-cloud/) (APC) also disables telemetry by
 default, setting both `SCARF_NO_ANALYTICS=True` and `DO_NOT_TRACK=True` in all Deployments, regardless of
@@ -24,7 +24,7 @@ It assists the project maintainers in better understanding how DAG Factory is us
 Insights gained from this telemetry are critical for prioritizing patches, minor releases, and
 security fixes. Additionally, this information supports key decisions related to the development roadmap.
 
-Deployments and individual users can opt out of analytics by setting the configuration:
+Deployments and individual users can opt out of telemetry by setting the configuration:
 
 ```ini
 [dag_factory]

--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -1,26 +1,47 @@
 # Privacy Notice
 
+By default, telemetry is disabled for Astronomer customers — see [Telemetry on Astronomer](#telemetry-on-astronomer) for details.
+
 This project follows the [Privacy Policy of Astronomer](https://www.astronomer.io/privacy/).
+
+## Telemetry on Astronomer
+
+Since May 2025, [Astro Runtime](https://www.astronomer.io/docs/runtime/runtime-release-notes) images set the
+environment variable `SCARF_NO_ANALYTICS=True`, which disables DAG Factory telemetry by default:
+
+- Airflow 3-based images: Astro Runtime 3.0-2 and newer
+- Airflow 2-based images: Astro Runtime 11.18.0, 12.9.0, 13.0.0 and newer
+
+[Astro Private Cloud](https://www.astronomer.io/docs/astro-private-cloud/) (APC) also disables telemetry by
+default, setting both `SCARF_NO_ANALYTICS=True` and `DO_NOT_TRACK=True` in all Deployments, regardless of
+the Astro Runtime version.
 
 ## Collection of Data
 
 DAG Factory integrates [Scarf](https://about.scarf.sh/) to collect basic telemetry data during operation.
-This data assists the project maintainers in better understanding how DAG Factory is used.
+This data is collected and processed by Scarf in accordance with the [Scarf Privacy Policy](https://about.scarf.sh/privacy-policy/).
+It assists the project maintainers in better understanding how DAG Factory is used.
 Insights gained from this telemetry are critical for prioritizing patches, minor releases, and
-security fixes. Additionally, this information supports key decisions related to the development road map.
+security fixes. Additionally, this information supports key decisions related to the development roadmap.
 
-Deployments and individual users can opt-out of analytics by setting the configuration:
+Deployments and individual users can opt out of analytics by setting the configuration:
 
 ```ini
 [dag_factory]
-enable_telemetry False
+enable_telemetry = False
 ```
 
-As described in the [official documentation](https://docs.scarf.sh/gateway/#do-not-track), it is also possible to opt out by setting one of the following environment variables:
+or the equivalent environment variable:
 
 ```commandline
-    DO_NOT_TRACK=True
-    SCARF_NO_ANALYTICS=True
+AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=False
+```
+
+As described in the [Scarf documentation](https://docs.scarf.sh/gateway/#do-not-track), it is also possible to opt out by setting one of the following environment variables:
+
+```commandline
+DO_NOT_TRACK=True
+SCARF_NO_ANALYTICS=True
 ```
 
 In addition to Scarf's default data collection, DAG Factory collects the following information:
@@ -35,4 +56,6 @@ In addition to Scarf's default data collection, DAG Factory collects the followi
 - Total tasks associated to each DagRun
 - Dag hash
 
-No user-identifiable information (IP included) is stored in Scarf.
+Astronomer does not track user-identifiable information through DAG Factory telemetry.
+For details on how Scarf handles the collected data, please refer to the
+[Scarf Privacy Policy](https://about.scarf.sh/privacy-policy/).

--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -1,6 +1,6 @@
 # Privacy Notice
 
-By default, telemetry is disabled for Astronomer customers — see [Telemetry on Astronomer](#telemetry-on-astronomer) for details.
+By default, telemetry is disabled for Astronomer customers running recent Astro Runtime images or Astro Private Cloud — see [Telemetry on Astronomer](#telemetry-on-astronomer) for the specific versions.
 
 This project follows the [Privacy Policy of Astronomer](https://www.astronomer.io/privacy/).
 

--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -28,20 +28,20 @@ Deployments and individual users can opt out of analytics by setting the configu
 
 ```ini
 [dag_factory]
-enable_telemetry = False
+enable_telemetry = false
 ```
 
 or the equivalent environment variable:
 
-```commandline
-AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=False
+```bash
+AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=false
 ```
 
-As described in the [Scarf documentation](https://docs.scarf.sh/gateway/#do-not-track), it is also possible to opt out by setting one of the following environment variables:
+As described in the [Scarf documentation](https://docs.scarf.sh/gateway/#do-not-track), it is also possible to opt out by setting one of the following environment variables (values are case-insensitive):
 
-```commandline
-DO_NOT_TRACK=True
-SCARF_NO_ANALYTICS=True
+```bash
+DO_NOT_TRACK=true
+SCARF_NO_ANALYTICS=true
 ```
 
 In addition to Scarf's default data collection, DAG Factory collects the following information:

--- a/PRIVACY_NOTICE.md
+++ b/PRIVACY_NOTICE.md
@@ -34,14 +34,14 @@ enable_telemetry = false
 or the equivalent environment variable:
 
 ```bash
-AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=false
+export AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=false
 ```
 
 As described in the [Scarf documentation](https://docs.scarf.sh/gateway/#do-not-track), it is also possible to opt out by setting one of the following environment variables (values are case-insensitive):
 
 ```bash
-DO_NOT_TRACK=true
-SCARF_NO_ANALYTICS=true
+export DO_NOT_TRACK=true
+export SCARF_NO_ANALYTICS=true
 ```
 
 In addition to Scarf's default data collection, DAG Factory collects the following information:


### PR DESCRIPTION
## Description

Improves the privacy notice, mirroring astronomer/astronomer-cosmos#2910:

- State upfront that telemetry is disabled by default for Astronomer customers, with a dedicated *Telemetry on Astronomer* section: Astro Runtime images set `SCARF_NO_ANALYTICS=True` since 3.0-2 (Airflow 3-based) and 11.18.0 / 12.9.0 / 13.0.0 (Airflow 2-based), and Astro Private Cloud sets `SCARF_NO_ANALYTICS=True` and `DO_NOT_TRACK=True` for all Deployments.
- Link [Scarf's Privacy Policy](https://about.scarf.sh/privacy-policy/) where we mention data is collected by Scarf.
- Stop making claims about what Scarf stores; say Astronomer does not track user-identifiable information and defer the rest to Scarf's policy.
- Fix the opt-out config example (proper ini format), document the `AIRFLOW__DAG_FACTORY__ENABLE_TELEMETRY=False` env var alternative, and fix minor grammar issues.

## Related Issue(s)

None.

## Breaking Change?

No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)