### PR TITLE
fix: validate Python callable file and name together

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -354,6 +354,13 @@ class DagBuilder:
                     "from a file. with the special pyyaml notation:\n"
                     "  python_callable_file: !!python/name:my_module.my_func"
                 )
+            if not task_params.get("python_callable") and bool(task_params.get("python_callable_name")) != bool(
+                task_params.get("python_callable_file")
+            ):
+                raise DagFactoryException(
+                    "Failed to create task. `python_callable_name` and "
+                    "`python_callable_file` must be provided together."
+                )
             if not task_params.get("python_callable"):
                 task_params["python_callable"]: Callable = utils.get_python_callable(
                     task_params["python_callable_name"], task_params["python_callable_file"]

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -341,27 +341,21 @@ class DagBuilder:
         operator_obj: Callable[..., BaseOperator] = import_string(operator)
         # pylint: disable=too-many-nested-blocks
         if issubclass(operator_obj, PYTHON_CALLABLE_CLASSES):
-            if (
-                not task_params.get("python_callable")
-                and not task_params.get("python_callable_name")
-                and not task_params.get("python_callable_file")
-            ):
-                # pylint: disable=line-too-long
-                raise DagFactoryException(
-                    "Failed to create task. PythonOperator, BranchPythonOperator and PythonSensor requires \
-                    `python_callable_name` and `python_callable_file` "
-                    "parameters.\nOptionally you can load python_callable "
-                    "from a file. with the special pyyaml notation:\n"
-                    "  python_callable_file: !!python/name:my_module.my_func"
-                )
-            if not task_params.get("python_callable") and bool(task_params.get("python_callable_name")) != bool(
-                task_params.get("python_callable_file")
-            ):
-                raise DagFactoryException(
-                    "Failed to create task. `python_callable_name` and "
-                    "`python_callable_file` must be provided together."
-                )
             if not task_params.get("python_callable"):
+                if not task_params.get("python_callable_name") and not task_params.get("python_callable_file"):
+                    # pylint: disable=line-too-long
+                    raise DagFactoryException(
+                        "Failed to create task. PythonOperator, BranchPythonOperator and PythonSensor requires \
+                        `python_callable_name` and `python_callable_file` "
+                        "parameters.\nOptionally you can load python_callable "
+                        "from a file. with the special pyyaml notation:\n"
+                        "  python_callable_file: !!python/name:my_module.my_func"
+                    )
+                if bool(task_params.get("python_callable_name")) != bool(task_params.get("python_callable_file")):
+                    raise DagFactoryException(
+                        "Failed to create task. `python_callable_name` and "
+                        "`python_callable_file` must be provided together."
+                    )
                 task_params["python_callable"]: Callable = utils.get_python_callable(
                     task_params["python_callable_name"], task_params["python_callable_file"]
                 )

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -496,11 +496,26 @@ def test_python_callable_resolution_both_paths(operator_path):
     assert "python_callable_file" not in task_params
 
 
-def test_make_python_operator_missing_param():
+@pytest.mark.parametrize(
+    "task_params",
+    [
+        pytest.param(
+            {"task_id": "test_task", "python_callable_name": "print_test"},
+            id="missing-file",
+        ),
+        pytest.param(
+            {"task_id": "test_task", "python_callable_file": os.path.realpath(__file__)},
+            id="missing-name",
+        ),
+    ],
+)
+def test_make_python_operator_missing_param(task_params):
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
     operator = get_python_operator_path()
-    task_params = {"task_id": "test_task", "python_callable_name": "print_test"}
-    with pytest.raises(Exception):
+    with pytest.raises(
+        DagFactoryException,
+        match="`python_callable_name` and `python_callable_file` must be provided together",
+    ):
         td.make_task(operator, task_params)
 
 
@@ -508,7 +523,7 @@ def test_make_python_operator_missing_params():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
     operator = get_python_operator_path()
     task_params = {"task_id": "test_task"}
-    with pytest.raises(Exception):
+    with pytest.raises(DagFactoryException):
         td.make_task(operator, task_params)
 
 


### PR DESCRIPTION
## Summary

- validate that `python_callable_name` and `python_callable_file` are provided together
- raise a clear `DagFactoryException` for either incomplete configuration
- cover both missing-pair cases and tighten the existing exception assertion

## Root cause

The builder only rejected configurations where all Python callable options were absent. When exactly one file-based callable parameter was provided, it accessed the missing dictionary key directly and raised `KeyError`.

## Validation

- `hatch run tests.py3.11-3.2:test` — 295 passed, 7 skipped, 1 deselected
- `pytest tests/test_dagbuilder.py -q` — 87 passed, 4 skipped
- applicable pre-commit checks on the changed files

Fixes #101
