### PR TITLE
Group github/codeql-action updates in a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,13 @@ updates:
 - cooldown:
     default-days: 7
   directory: /
+  groups:
+    # Keep github/codeql-action/init and github/codeql-action/analyze in a single PR.
+    # CodeQL requires init and analyze to run the same version; bumping them in
+    # separate PRs leaves the pair version-skewed and fails the Analyze job.
+    codeql-action:
+      patterns:
+      - "github/codeql-action*"
   ignore:
   - dependency-name: "github/gh-aw-actions*" # gh-aw compiler-managed action pin (incl. sub-actions like /setup); keep ignored and refresh via gh aw compile.
   labels:


### PR DESCRIPTION
## Summary

Group `github/codeql-action*` updates into a single Dependabot PR.

CodeQL requires the `init` and `analyze` actions to run the **same** version. Dependabot was opening `github/codeql-action/init` and `github/codeql-action/analyze` as **separate** PRs, so each branch ended up with a version-skewed init/analyze pair and failed the `Analyze (actions)` / `Analyze (python)` jobs (e.g. #847 + #848). Grouping them prevents this from recurring on every codeql release.

## Fix

Add a `codeql-action` group to the `github-actions` ecosystem so both sub-actions bump together in one PR that lands at a single, consistent version and passes CI.

```yaml
groups:
  codeql-action:
    patterns:
    - "github/codeql-action*"
```

The existing `github/gh-aw-actions*` ignore, cooldown, schedule, labels, and reviewers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
