### PR TITLE
fix: capture dashes in dataset names for dataset conditions

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -303,7 +303,9 @@ def get_datasets_map_uri_yaml_file(file_path: str, datasets_filter: str) -> Dict
 
 
 def extract_dataset_names(expression) -> List[str]:
-    dataset_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
+    # Asset/dataset names may contain "-", which must be captured as part of the
+    # identifier instead of being treated as a separator (see issue #629).
+    dataset_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*(?:-[a-zA-Z0-9_]+)*\b"
     datasets = re.findall(dataset_pattern, expression)
     return datasets
 

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -302,17 +302,23 @@ def get_datasets_map_uri_yaml_file(file_path: str, datasets_filter: str) -> Dict
         raise
 
 
+STORAGE_PATTERN = r"[a-zA-Z][a-zA-Z0-9+.-]*://[a-zA-Z0-9\-_/\.]+"
+
+
 def extract_dataset_names(expression) -> List[str]:
     # Asset/dataset names may contain "-", which must be captured as part of the
     # identifier instead of being treated as a separator (see issue #629).
+    # Storage URIs are removed first: they are handled by extract_storage_names,
+    # and their dashed components (e.g. "bucket-cjmm" in "s3://bucket-cjmm/raw")
+    # would otherwise be returned here and rewritten inside the URI.
     dataset_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*(?:-[a-zA-Z0-9_]+)*\b"
-    datasets = re.findall(dataset_pattern, expression)
+    expression_without_uris = re.sub(STORAGE_PATTERN, " ", expression)
+    datasets = re.findall(dataset_pattern, expression_without_uris)
     return datasets
 
 
 def extract_storage_names(expression) -> List[str]:
-    storage_pattern = r"[a-zA-Z][a-zA-Z0-9+.-]*://[a-zA-Z0-9\-_/\.]+"
-    storages = re.findall(storage_pattern, expression)
+    storages = re.findall(STORAGE_PATTERN, expression)
     return storages
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -317,6 +317,18 @@ def test_extract_dataset_names():
     assert result == expected
 
 
+def test_extract_dataset_names_with_dashes():
+    expression = "(asset-1 & asset2)"
+    expected = ["asset-1", "asset2"]
+    result = utils.extract_dataset_names(expression)
+    assert result == expected
+
+    expression = "my-asset-1 | other_asset & third-asset"
+    expected = ["my-asset-1", "other_asset", "third-asset"]
+    result = utils.extract_dataset_names(expression)
+    assert result == expected
+
+
 def test_extract_storage_names():
     expression = "s3://bucket-cjmm/raw/dataset_custom_1 & s3://bucket-cjmm/raw/dataset_custom_2"
     expected = ["s3://bucket-cjmm/raw/dataset_custom_1", "s3://bucket-cjmm/raw/dataset_custom_2"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -329,6 +329,17 @@ def test_extract_dataset_names_with_dashes():
     assert result == expected
 
 
+def test_extract_dataset_names_ignores_storage_uris():
+    # Storage URIs are handled by extract_storage_names; their components must not
+    # be returned here, otherwise "bucket-cjmm" would be rewritten inside the URI.
+    expression = "s3://bucket-cjmm/raw/dataset_custom_1 & s3://bucket-cjmm/raw/dataset_custom_2"
+    assert utils.extract_dataset_names(expression) == []
+
+    expression = "s3://bucket-cjmm/raw/dataset_custom_1 & asset-1"
+    assert utils.extract_dataset_names(expression) == ["asset-1"]
+    assert utils.extract_storage_names(expression) == ["s3://bucket-cjmm/raw/dataset_custom_1"]
+
+
 def test_extract_storage_names():
     expression = "s3://bucket-cjmm/raw/dataset_custom_1 & s3://bucket-cjmm/raw/dataset_custom_2"
     expected = ["s3://bucket-cjmm/raw/dataset_custom_1", "s3://bucket-cjmm/raw/dataset_custom_2"]


### PR DESCRIPTION
Closes #629

Airflow asset names may contain `-`, but `utils.extract_dataset_names` tokenized on word characters only, so `extract_dataset_names("(asset-1 & asset2)")` returned `['asset', 'asset2']` and the dataset map was built for names that do not exist. The identifier pattern now allows internal dashes while still rejecting names that start with a digit; `make_valid_variable_name` is unchanged, so the expression still evaluates against a valid Python identifier (`asset_1`) while the external asset name stays `asset-1` — the shape @ErickSeo outlined in the issue thread.

Regression test `test_extract_dataset_names_with_dashes` in `tests/test_utils.py` fails on `main` (`assert ['asset', 'asset2'] == ['asset-1', 'asset2']`) and passes with the fix; `tests/test_utils.py` and `tests/test_parsers.py` are green (58 passed).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
